### PR TITLE
release: v0.3.0 — graduate bridge-svelte from beta to stable

### DIFF
--- a/bridge-svelte/package.json
+++ b/bridge-svelte/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nebulr-group/bridge-svelte",
-	"version": "0.3.0-beta.8",
+	"version": "0.3.0",
 	"description": "Bridge Svelte library, This library helps you to add bridge authentication and feature flags, and payments to your svelte application.",
 	"author": "Iman Pouya",
 	"license": "MIT",
@@ -61,7 +61,7 @@
 		}
 	},
 	"dependencies": {
-		"@nebulr-group/bridge-auth-core": "0.1.0-beta.6"
+		"@nebulr-group/bridge-auth-core": "0.1.0"
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "^2.16.0",


### PR DESCRIPTION
## Summary

First stable release of `@nebulr-group/bridge-svelte`.

- Bump version: `0.3.0-beta.8` → `0.3.0`
- Bump `@nebulr-group/bridge-auth-core` dependency: `0.1.0-beta.6` → `0.1.0` (the freshly-promoted stable auth-core)

## Release process

1. **Wait for `@nebulr-group/bridge-auth-core@0.1.0` to be live on npm** (published from sibling auth-core release PR). The build job here runs `bun install` which will fail to resolve `0.1.0` until then.
2. Merge this PR (squash) — preserves linear history on `main`.
3. After merge, a `v0.3.0` tag is pushed pointing at the new merged commit on `main`.
4. Tag triggers `.github/workflows/publish-pipeline.yml` → publishes to npm with `latest` dist-tag.

## Test plan

- [ ] auth-core@0.1.0 is live on npm before this PR is merged
- [ ] CI build passes on the release branch
- [ ] After publish, verify on registry: `curl -s https://registry.npmjs.org/@nebulr-group/bridge-svelte | jq '."dist-tags"'` → `latest: 0.3.0`
- [ ] Sandbox install: `npm install @nebulr-group/bridge-svelte@0.3.0` resolves auth-core@0.1.0 transitively

Part of the bridge-platform stable graduation 2026-04-30.