### PR TITLE
chore: bump auth-core to 0.1.1, release 0.3.1 (TBP-125)

### DIFF
--- a/bridge-svelte/package.json
+++ b/bridge-svelte/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nebulr-group/bridge-svelte",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "Bridge Svelte library, This library helps you to add bridge authentication and feature flags, and payments to your svelte application.",
 	"author": "Iman Pouya",
 	"license": "MIT",
@@ -61,7 +61,7 @@
 		}
 	},
 	"dependencies": {
-		"@nebulr-group/bridge-auth-core": "0.1.0"
+		"@nebulr-group/bridge-auth-core": "0.1.1"
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "^2.16.0",


### PR DESCRIPTION
## Summary

Bumps \`@nebulr-group/bridge-auth-core\` to **0.1.1** and releases bridge-svelte **0.3.1** so consumers get the new \`redeemCloudViewsSession\` SDK method (auto-available via the existing \`getBridgeAuth\` re-export — no bridge-svelte source changes needed).

Part of [TBP-125](https://huly.thebridge.dev) — Federated CLI login via OAuth state.

## Why

Cloud-views' \`/cli/authorize\` page needs to call \`getBridgeAuth().redeemCloudViewsSession(ticket)\` to redeem the one-shot session ticket bridge-api hands back after federated CLI login. The method ships in auth-core 0.1.1; this PR bumps the dep so it lands in bridge-svelte's distributed bundle.

Patch bump: **0.3.0 → 0.3.1** (additive, no breaking changes).

## Test plan

- [ ] Build passes locally (verified).
- [ ] Published to Verdaccio (0.3.1 tarball available, consumed by bridge-cloud-views stage).
- [ ] Pending public npm release once auth-core 0.1.1 PR (auth-core#TBD) merges.