### PR TITLE
release: v0.3.2

### DIFF
--- a/bridge-svelte/package.json
+++ b/bridge-svelte/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nebulr-group/bridge-svelte",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"description": "Bridge Svelte library, This library helps you to add bridge authentication and feature flags, and payments to your svelte application.",
 	"author": "Iman Pouya",
 	"license": "MIT",
@@ -61,7 +61,7 @@
 		}
 	},
 	"dependencies": {
-		"@nebulr-group/bridge-auth-core": "0.1.1"
+		"@nebulr-group/bridge-auth-core": "0.1.2"
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "^2.16.0",


### PR DESCRIPTION
## Summary

Patch release wiring TBP-142 cross-tab session-stale into the Svelte SDK and bumping the auth-core dependency.

## Changes

- **TBP-142**: surface auth-core's new `sessionStale` event through bridge-svelte so consuming SvelteKit apps can react (typical pattern: show a recovery dialog and redirect to login).
- **deps**: `@nebulr-group/bridge-auth-core` → `0.1.2` (was previously pinned at the local Verdaccio alpha `0.2.0-alpha.1`).

## CI note

Until `@nebulr-group/bridge-auth-core@0.1.2` is live on public npm, this PR's `bun install` step will fail to resolve the new auth-core version. **Expected** — re-run after auth-core's PR merges and tags.

## Release process

- Branch protection: tag `v0.3.2` will be pushed to the merged commit on `main` after this PR squash-merges.
- Triggers `publish-pipeline.yml` → publishes `@nebulr-group/bridge-svelte@0.3.2` to public npm.