### PR TITLE
test(e2e): link demo app to 'Bridge Plugin Demos' workspace (TBP-239)

### DIFF
--- a/e2e/playwright/pre-setup.ts
+++ b/e2e/playwright/pre-setup.ts
@@ -69,34 +69,35 @@ async function preSetup() {
   }
   console.log(`[pre-setup] Health check passed`);
 
-  // In local-dev mode, look up the developer's admin tenant in NBLOCKS_DASHBOARD
-  // so we can link the new test app to it — that makes the app visible in the
-  // admin UI at localhost:3023 under that admin user. CI / stage / prod skip
-  // this; the app stays unlinked (fine for throwaway test runs).
+  // In local-dev mode, ensure the dedicated "Bridge Plugin Demos" workspace exists in
+  // NBLOCKS_DASHBOARD and link the new test app to it. That puts demo apps in their own
+  // workspace in the admin UI at localhost:3023, separate from the developer's main work.
+  // CI / stage / prod don't auto-run this — for those, use the standalone setup script in
+  // bridge-api/scripts/setup-sdk-demos-workspace.sh (see bridge-api README).
   let adminTenantId: string | undefined;
   if (mode === 'test.local') {
     try {
       const tenantRes = await fetch(
-        `${testDataApiUrl}/account/test/playwright/local-admin-tenant`,
+        `${testDataApiUrl}/account/test/playwright/sdk-demos-workspace`,
         { method: 'GET', headers: { 'x-playwright-api-key': apiKey } },
       );
       if (tenantRes.ok) {
-        const { tenantId, email } = await tenantRes.json();
+        const { tenantId, name } = await tenantRes.json();
         if (tenantId) {
           adminTenantId = tenantId;
-          console.log(`[pre-setup] Will link test app to admin tenant ${tenantId} (${email})`);
+          console.log(`[pre-setup] Will link test app to "${name}" workspace (${tenantId})`);
         } else {
-          console.log('[pre-setup] No local admin tenant found — app will not be visible in admin UI.');
+          console.log('[pre-setup] SDK demos workspace not available — app will not appear in admin UI.');
         }
       } else if (tenantRes.status === 404) {
         // bridge-api running an older build without the endpoint — older behaviour
-        console.log('[pre-setup] local-admin-tenant endpoint not available — skipping admin UI link.');
+        console.log('[pre-setup] sdk-demos-workspace endpoint not available — skipping admin UI link.');
       } else {
-        console.log(`[pre-setup] local-admin-tenant lookup returned ${tenantRes.status} — skipping admin UI link.`);
+        console.log(`[pre-setup] sdk-demos-workspace lookup returned ${tenantRes.status} — skipping admin UI link.`);
       }
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
-      console.log(`[pre-setup] local-admin-tenant lookup failed (${msg}) — skipping admin UI link.`);
+      console.log(`[pre-setup] sdk-demos-workspace lookup failed (${msg}) — skipping admin UI link.`);
     }
   }
 

--- a/e2e/playwright/pre-setup.ts
+++ b/e2e/playwright/pre-setup.ts
@@ -69,6 +69,37 @@ async function preSetup() {
   }
   console.log(`[pre-setup] Health check passed`);
 
+  // In local-dev mode, look up the developer's admin tenant in NBLOCKS_DASHBOARD
+  // so we can link the new test app to it — that makes the app visible in the
+  // admin UI at localhost:3023 under that admin user. CI / stage / prod skip
+  // this; the app stays unlinked (fine for throwaway test runs).
+  let adminTenantId: string | undefined;
+  if (mode === 'test.local') {
+    try {
+      const tenantRes = await fetch(
+        `${testDataApiUrl}/account/test/playwright/local-admin-tenant`,
+        { method: 'GET', headers: { 'x-playwright-api-key': apiKey } },
+      );
+      if (tenantRes.ok) {
+        const { tenantId, email } = await tenantRes.json();
+        if (tenantId) {
+          adminTenantId = tenantId;
+          console.log(`[pre-setup] Will link test app to admin tenant ${tenantId} (${email})`);
+        } else {
+          console.log('[pre-setup] No local admin tenant found — app will not be visible in admin UI.');
+        }
+      } else if (tenantRes.status === 404) {
+        // bridge-api running an older build without the endpoint — older behaviour
+        console.log('[pre-setup] local-admin-tenant endpoint not available — skipping admin UI link.');
+      } else {
+        console.log(`[pre-setup] local-admin-tenant lookup returned ${tenantRes.status} — skipping admin UI link.`);
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.log(`[pre-setup] local-admin-tenant lookup failed (${msg}) — skipping admin UI link.`);
+    }
+  }
+
   // Create or get the test app
   console.log(`[pre-setup] Setting up test app (domain: ${testAppDomain})...`);
   const setupRes = await fetch(`${testDataApiUrl}/account/test/playwright/setup-test-app`, {
@@ -83,6 +114,7 @@ async function preSetup() {
       ownerEmail,
       ownerPassword,
       appUrl: 'http://localhost:3001',
+      ...(adminTenantId ? { adminTenantId } : {}),
     }),
   });
 


### PR DESCRIPTION
## Summary

Pre-setup now fetches the dedicated "Bridge Plugin Demos" workspace tenant from bridge-api's new `GET /account/test/playwright/sdk-demos-workspace` endpoint and passes it as `adminTenantId` to `setup-test-app`. The local-dev `BRIDGE_SVELTE_TEST_DASHBOARD` then appears in the admin UI under its own workspace, separate from the developer's main work.

Ticket: [TBP-239](https://huly.app/...)

## Depends on

This PR depends on the new `/sdk-demos-workspace` endpoint shipped in:
- bridge-api MR !23 (`fix/app-creation-invariant`)

**Merge that MR first.** Pre-setup degrades gracefully if the endpoint is missing (creates the app unlinked, logs a friendly note), so this PR is technically safe to merge on its own — but the demo app won't appear in the workspace until bridge-api ships.

## Changes

- `e2e/playwright/pre-setup.ts` — gated to `mode === 'test.local'`, fetches the workspace tenant and forwards as `adminTenantId`. 404 / null / network error all degrade gracefully without crashing pre-setup.

## Test plan

- [x] Pre-setup run logs "Will link test app to 'Bridge Plugin Demos' workspace"
- [x] DB verified: `BRIDGE_SVELTE_TEST_DASHBOARD` has `metaData.nblocksTenant` pointing at the demos workspace
- [x] Demo app appears in admin UI at localhost:3023 under the new workspace grouping

## Notes for reviewer

Minor change — 1 file, +24/-11 across two commits (the second commit just renames `local-admin-tenant` → `sdk-demos-workspace` to match the final bridge-api endpoint name).

Stage/prod handled separately via `bridge-api/scripts/setup-sdk-demos-workspace.sh <env>` — that script knows about every SDK demo dashboard (including this one).