### PR TITLE
release: v0.3.3

### DIFF
--- a/bridge-svelte/package.json
+++ b/bridge-svelte/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nebulr-group/bridge-svelte",
-	"version": "0.3.2",
+	"version": "0.3.3",
 	"description": "Bridge Svelte library, This library helps you to add bridge authentication and feature flags, and payments to your svelte application.",
 	"author": "Iman Pouya",
 	"license": "MIT",


### PR DESCRIPTION
## Summary

Patch release shipping the plugin half of TBP-239:

- Pre-setup now links the `BRIDGE_SVELTE_TEST_DASHBOARD` demo app to the dedicated **"Bridge Plugin Demos"** workspace in NBLOCKS_DASHBOARD via bridge-api's new `GET /account/test/playwright/sdk-demos-workspace` endpoint
- Demo apps appear in their own grouping in the admin UI under the primary admin user — visually separated from the developer's main workspace
- Local-mode only (CI / stage / prod skip the lookup); pre-setup degrades gracefully if the endpoint is missing on older bridge-api builds

Ticket: TBP-239
Companion: bridge-nextjs v0.3.3 release (PR will follow)
Backend dependency: bridge-api MR !23 (merged to stage today)

## End-user (OSS consumer) impact

None — end users set `VITE_BRIDGE_APP_ID` in env themselves and never hit the test endpoints. The workspace linking is purely a Bridge plugin dev workflow.

## Test plan

- [x] Full Playwright E2E suite green
- [x] Manual: demo app appears in admin UI under "Bridge Plugin Demos" workspace after pre-setup runs

## Notes

- `@nebulr-group/bridge-auth-core` dep stays at `0.1.2` — not bumping auth-core this release
- Single-commit release branch (just the version bump). Per-feature work landed via PR #19 earlier today.