### PR TITLE
release: v0.4.0-beta.2 — auth-core beta.2 pin + demo probe fixes

### DIFF
--- a/bridge-svelte/package.json
+++ b/bridge-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebulr-group/bridge-svelte",
-  "version": "0.4.0-beta.1",
+  "version": "0.4.0-beta.2",
   "description": "Bridge Svelte library, This library helps you to add bridge authentication and feature flags, and payments to your svelte application.",
   "author": "Iman Pouya",
   "license": "MIT",
@@ -67,7 +67,7 @@
     }
   },
   "dependencies": {
-    "@nebulr-group/bridge-auth-core": "0.4.0-beta.1"
+    "@nebulr-group/bridge-auth-core": "0.4.0-beta.2"
   },
   "devDependencies": {
     "@sveltejs/kit": "^2.16.0",

--- a/demo/src/routes/attr-probe/+page.svelte
+++ b/demo/src/routes/attr-probe/+page.svelte
@@ -5,6 +5,15 @@
     ?key=<flag-key>               — which flag to evaluate (required)
     ?attrs=<json>                 — per-call attributes (optional)
     ?attrs_b64=<base64-json>      — per-call attributes, base64-encoded (optional)
+    ?defaultType=<boolean|string|number|json>
+                                  — declared type of the dev default (optional)
+    ?defaultValue=<json>          — dev default passed to the SDK (optional).
+                                    The SDK's fail-safe type guard falls back to
+                                    this default whenever the server value's type
+                                    doesn't match it — so typed-flag tests MUST
+                                    send a default of the matching type, else
+                                    string/number/json flags always render the
+                                    fallback branch. Defaults to `false`.
 
   Playwright testids (unchanged):
     [data-testid="probe-state"]      — "active" | "fallback"
@@ -13,6 +22,7 @@
     [data-testid="probe-key"]        — resolved flag key
     [data-testid="probe-attrs"]      — JSON-stringified attrs
     [data-testid="probe-default"]    — JSON-stringified default
+    [data-testid="probe-app-id"]     — appId the SDK booted with (fail-fast guard)
 -->
 <script lang="ts">
   import { page } from '$app/state';
@@ -34,13 +44,31 @@
     } catch { return {}; }
   }
 
+  // Dev default for the FeatureFlag. JSON-decoding the param yields the typed
+  // value directly ('"light"' → string, '0' → number, '{...}' → object);
+  // `defaultType` is advisory — a malformed pair degrades to `false` rather
+  // than breaking the probe for unrelated boolean tests.
+  function parseDefault(): unknown {
+    const raw = page.url.searchParams.get('defaultValue');
+    if (raw === null) return false;
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return false;
+    }
+  }
+
   const flagKey = $derived((page.url.searchParams.get('key') ?? '').trim());
   const attrs = $derived(parseAttrs());
   const hasAttrs = $derived(Object.keys(attrs).length > 0);
+  const probeDefault = $derived(parseDefault());
 </script>
 
 <div class="page">
   <div class="container">
+    <!-- The appId the SDK is actually running with — lets tests fail fast
+         when the demo and the test harness disagree on the app under test. -->
+    <span class="sr-only" data-testid="probe-app-id">{page.data.config?.appId ?? ''}</span>
     <h1 class="heading-xl">Flag probe</h1>
     <p class="text-lead">
       Evaluates any flag by key. Used by tests and for manual inspection — pass
@@ -61,7 +89,7 @@
 
         <!-- Live result -->
         <div class="demo-output">
-          <FeatureFlag key={flagKey} defaultValue={false} context={hasAttrs ? { attributes: attrs } : undefined}>
+          <FeatureFlag key={flagKey} defaultValue={probeDefault} context={hasAttrs ? { attributes: attrs } : undefined}>
             {#snippet children(value)}
               <div class="flag-result flag-result--on">
                 ✅ <strong>{flagKey}</strong> is <strong>ON</strong>
@@ -70,7 +98,7 @@
                 <span data-testid="probe-state">active</span>
                 <span data-testid="probe-value">{JSON.stringify(value)}</span>
                 <span data-testid="probe-value-type">{typeof value}</span>
-                <span data-testid="probe-default">false</span>
+                <span data-testid="probe-default">{JSON.stringify(probeDefault)}</span>
                 <span data-testid="probe-key">{flagKey}</span>
                 <span data-testid="probe-attrs">{JSON.stringify(attrs)}</span>
               </div>
@@ -83,7 +111,7 @@
                 <span data-testid="probe-state">fallback</span>
                 <span data-testid="probe-value">{JSON.stringify(value)}</span>
                 <span data-testid="probe-value-type">{typeof value}</span>
-                <span data-testid="probe-default">false</span>
+                <span data-testid="probe-default">{JSON.stringify(probeDefault)}</span>
                 <span data-testid="probe-key">{flagKey}</span>
                 <span data-testid="probe-attrs">{JSON.stringify(attrs)}</span>
               </div>

--- a/demo/src/routes/discovery-probe/+page.svelte
+++ b/demo/src/routes/discovery-probe/+page.svelte
@@ -29,4 +29,7 @@
   <p>
     State: <strong data-testid="probe-state">{state}</strong>
   </p>
+  <p>
+    App: <code data-testid="probe-app-id">{page.data.config?.appId ?? ''}</code>
+  </p>
 </section>

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "mdx-to-md": "^0.5.2"
   },
   "dependencies": {
-    "@nebulr-group/bridge-auth-core": "0.4.0-beta.1"
+    "@nebulr-group/bridge-auth-core": "0.4.0-beta.2"
   },
   "version": "0.1.0-beta.0"
 }


### PR DESCRIPTION
## What ships

- **chore**: bump `@nebulr-group/bridge-auth-core` `0.4.0-beta.1` → `0.4.0-beta.2` in both the plugin package and the workspace root (TBP-398: anonymous sessions no longer hot-loop `POST /usage/ingest` 401s — usage events from unauthenticated sessions are dropped at the door)
- **fix(demo)**: attr-probe honors `defaultType`/`defaultValue` URL params — typed `FeatureFlag` defaults exercised by the bridge-api app-integration suite
- **feat(demo)**: expose `probe-app-id` testid on probe routes (suite asserts the SDK is wired to the expected app)

### Validation
Both changes validated against the bridge-api `local-app-integration` Playwright suite: **41 passed / 0 failed / 2 skipped-by-design** (on the Verdaccio dev build of the same auth-core commit that ships as beta.2).

⚠️ CI on this PR will fail to resolve `bridge-auth-core@0.4.0-beta.2` until the auth-core release (thebridgedev/auth-core#6) is merged, tagged, and live on npm — expected; rerun after upstream publishes.

Release ticket: TBP-402 (items 1–2)