### PR TITLE
docs: svelte learning docs — Billing 2.0 + bridge-surface rewrite

### DIFF
--- a/learning/README.md
+++ b/learning/README.md
@@ -6,11 +6,13 @@ This directory contains the Bridge Svelte learning docs.
 
 - **[Hosted Auth Quickstart](quickstart/hosted-quickstart.md)** — Fastest path: Bridge handles the login UI on a hosted page.
 - **[SDK Auth Quickstart](sdk-auth/sdk-quickstart.md)** — In-app login/signup forms using SDK components. Includes a Styles section linking to [Theming](theming/theming.md) for CSS variable theming, component-level overrides, and headless usage.
+- **[Live Updates & the Bridge Surface](live-updates/live-updates.md)** — The unified `bridge` object (branding, workspace, subscription, entitlements, user), live channel events, and app-wide flag attributes.
+- **[Configuration Reference](configuration/configuration.md)** — The full `BridgeConfig` type, `bridgeBootstrap()` signature, route guard rules, and the `.env` pattern.
 - **[Examples](examples/examples.md)** — Detailed examples for every feature:
   - Authentication (route protection, auth status, profile, logout)
   - SDK auth components (LoginForm, SignupForm, MFA, passkeys, magic link, SSO, tenant/workspace selection)
   - Feature flags (component, route-level, programmatic access)
-  - Payments & subscriptions (PlanSelector, Stripe, billing portal)
+  - Payments & subscriptions (live subscription state, billing components, entitlements, PlanSelector, Stripe, billing portal)
   - Team management
   - API token management
   - Configuration reference

--- a/learning/auth/auth.md
+++ b/learning/auth/auth.md
@@ -104,6 +104,8 @@ Access the current user's profile with `profileStore`:
 
 `profileStore` is `undefined` while loading, `null` when not authenticated, and a profile object when authenticated.
 
+A live snapshot of the signed-in user (`id`, `email`, `role`, `tenantId`) plus workspace and subscription state is also available on the unified bridge surface (`bridge.user`, `bridge.tenant.*`), kept current over the live channel — see [Live Updates & the Bridge Surface](../live-updates/live-updates.md).
+
 ### ProfileName component
 
 A drop-in component that renders the user's display name. No configuration needed:

--- a/learning/configuration/configuration.md
+++ b/learning/configuration/configuration.md
@@ -1,0 +1,155 @@
+# Configuration Reference
+
+### BridgeConfig type
+
+The config object you pass to `bridgeBootstrap`:
+
+```typescript
+interface BridgeConfig {
+  /** Your Bridge application ID (required) */
+  appId: string;
+
+  /** Where the login flow redirects back to.
+   *  @default `${window.location.origin}/auth/oauth-callback` */
+  callbackUrl?: string;
+
+  /** Base URL for the Bridge API. All endpoints are derived from this.
+   *  @default 'https://api.thebridge.dev' */
+  apiBaseUrl?: string;
+
+  /** Base URL for the Bridge hosted UI (login page, plan selection, etc.).
+   *  @default 'https://auth.thebridge.dev' */
+  hostedUrl?: string;
+
+  /** Route to redirect to after login. @default '/' */
+  defaultRedirectRoute?: string;
+
+  /** In-app route of your login page. Leave unset for hosted auth —
+   *  without it, unauthenticated users go to the Bridge hosted login page. */
+  loginRoute?: string;
+
+  /** In-app route of your signup page (SDK auth). */
+  signupRoute?: string;
+
+  /** Billing routes used by the payment flow. */
+  billing?: {
+    /** Route to send billing-locked workspaces to. */
+    paywallRoute?: string;
+    /** Route to land on when a payment fails. */
+    paymentErrorRoute?: string;
+  };
+
+  /** Token storage adapter. Defaults to localStorage (browser) or memory (SSR). */
+  storage?: TokenStorage;
+
+  /** Enable debug logging. @default false */
+  debug?: boolean;
+}
+```
+
+### bridgeBootstrap()
+
+Call it from your root `+layout.ts` load function:
+
+```typescript
+// src/routes/+layout.ts
+import type { LayoutLoad } from './$types';
+import type { BridgeConfig, RouteGuardConfig } from '@nebulr-group/bridge-svelte';
+import { bridgeBootstrap } from '@nebulr-group/bridge-svelte';
+
+export const ssr = false;
+
+export const load: LayoutLoad = async ({ url, fetch }) => {
+  const config: BridgeConfig = {
+    appId: import.meta.env.VITE_BRIDGE_APP_ID,
+    loginRoute: '/auth/login',
+  };
+
+  const routeConfig: RouteGuardConfig = {
+    rules: [
+      { match: '/', public: true },
+      { match: new RegExp('^/auth($|/)'), public: true },
+    ],
+    defaultAccess: 'protected',
+  };
+
+  await bridgeBootstrap(url, config, routeConfig, fetch);
+  return {};
+};
+```
+
+Signature:
+
+```typescript
+bridgeBootstrap(
+  url: URL,                       // the current URL from the load function
+  config: BridgeConfig | string,  // config object, or just the appId as a string
+  routeConfig?: RouteGuardConfig, // default: { rules: [], defaultAccess: 'protected' }
+  kitFetch?: typeof fetch         // pass SvelteKit's fetch for SSR-safe requests
+)
+```
+
+Bootstrap is idempotent — calling it again after it has completed is a no-op.
+
+### RouteGuardConfig
+
+Declares which routes are public, protected, flag-gated, or billing-gated:
+
+```typescript
+interface RouteGuardConfig {
+  rules: RouteRule[];
+  /** Access for routes no rule matches. @default 'protected' */
+  defaultAccess?: 'public' | 'protected';
+}
+
+interface RouteRule {
+  /** Path to match — exact string or RegExp. */
+  match: string | RegExp;
+  /** Route is accessible without authentication. */
+  public?: boolean;
+  /** Require feature flag(s): a key, { any: [...] }, or { all: [...] }. */
+  featureFlag?: string | { any: string[] } | { all: string[] };
+  /** Where to send users who fail the featureFlag requirement. */
+  redirectTo?: string;
+  /** Billing gate. 'soft' (default) renders the route and relies on the
+   *  in-app notice; 'hard' redirects a billing-locked workspace to its
+   *  recovery URL. */
+  billing?: 'soft' | 'hard';
+}
+```
+
+### Passing values via .env
+
+Keep environment-specific values in a `.env` file instead of hardcoding them, and read them with Vite's `import.meta.env` when you build the config. The `VITE_` prefix is required for values to reach the browser; the SDK does not read environment variables automatically.
+
+```env
+VITE_BRIDGE_APP_ID=your-app-id-here
+VITE_BRIDGE_API_BASE_URL=https://api.thebridge.dev
+VITE_BRIDGE_DEFAULT_REDIRECT_ROUTE=/dashboard
+```
+
+```typescript
+const config: BridgeConfig = {
+  appId: import.meta.env.VITE_BRIDGE_APP_ID,
+  apiBaseUrl: import.meta.env.VITE_BRIDGE_API_BASE_URL,
+  defaultRedirectRoute: import.meta.env.VITE_BRIDGE_DEFAULT_REDIRECT_ROUTE ?? '/',
+  debug: import.meta.env.DEV,
+};
+```
+
+### Reading the resolved config
+
+Read the active config at runtime via the `readonlyConfig` store:
+
+```svelte
+<script lang="ts">
+  import { readonlyConfig } from '@nebulr-group/bridge-svelte';
+
+  const config = $derived($readonlyConfig);
+</script>
+
+{#if config}
+  <p>App ID: {config.appId}</p>
+  <p>API Base: {config.apiBaseUrl}</p>
+{/if}
+```

--- a/learning/examples/examples.md
+++ b/learning/examples/examples.md
@@ -9,71 +9,12 @@
 
 - [Authentication](../auth/auth.md) — Auth status, profile, logout, and all SDK auth components
 - [Feature Flags](../feature-flags/feature-flags.md) — FeatureFlag component, route-level flags, programmatic access
-- [Payments & Subscriptions](../payments/payments.md) — PlanSelector, Stripe checkout, subscription state
+- [Live Updates & the Bridge Surface](../live-updates/live-updates.md) — the unified `bridge` object, live channel events, app-wide attributes
+- [Payments & Subscriptions](../payments/payments.md) — live subscription state, billing components, entitlements, Stripe checkout
 - [Team Management](../team-management/team-management.md) — TeamManagementPanel
 - [API Token Management](../api-tokens/api-tokens.md) — ApiTokenManagement
 - [Theming & Styles](../theming/theming.md) — CSS variables, component-level overrides, headless usage
 
 ## Configuration
 
-### BridgeConfig object
-
-The `BridgeConfig` type (aliased from `BridgeAuthConfig` in `@nebulr-group/bridge-auth-core`) supports these fields:
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `appId` | `string` | **(required)** | Your Bridge application ID |
-| `loginRoute` | `string` | — | In-app route for your login page. Unauthenticated users are redirected here |
-| `defaultRedirectRoute` | `string` | `'/'` | Route to redirect to after login |
-| `apiBaseUrl` | `string` | `'https://api.thebridge.dev'` | Root URL for the Bridge API (dev override) |
-| `hostedUrl` | `string` | `'https://auth.thebridge.dev'` | Bridge hosted UI URL (dev override) |
-| `storage` | `TokenStorage` | localStorage (browser) / memory (SSR) | Token storage adapter |
-| `debug` | `boolean` | `false` | Enable debug logging |
-
-Example:
-
-```ts
-const config: BridgeConfig = {
-  appId: import.meta.env.VITE_BRIDGE_APP_ID,
-  loginRoute: '/auth/login',
-  defaultRedirectRoute: '/dashboard',
-  debug: import.meta.env.DEV,
-};
-```
-
-### Environment variables
-
-All Bridge config values can be set via environment variables in `.env`:
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `VITE_BRIDGE_APP_ID` | Your Bridge application ID | **(required)** |
-| `VITE_BRIDGE_API_BASE_URL` | Root URL for the Bridge API | `https://api.thebridge.dev` |
-| `VITE_BRIDGE_DEFAULT_REDIRECT_ROUTE` | Default route after login | `/` |
-| `VITE_BRIDGE_LOGIN_ROUTE` | Route for your login page | `/login` |
-| `VITE_BRIDGE_DEBUG` | Enable debug logging | `false` |
-
-Example `.env`:
-
-```env
-VITE_BRIDGE_APP_ID=your-app-id-here
-VITE_BRIDGE_DEFAULT_REDIRECT_ROUTE=/dashboard
-VITE_BRIDGE_LOGIN_ROUTE=/auth/login
-```
-
-### readonlyConfig store
-
-Read the resolved Bridge config at runtime:
-
-```svelte
-<script lang="ts">
-  import { readonlyConfig } from '@nebulr-group/bridge-svelte';
-
-  const config = $derived($readonlyConfig);
-</script>
-
-{#if config}
-  <p>App ID: {config.appId}</p>
-  <p>API Base: {config.apiBaseUrl}</p>
-{/if}
-```
+See the [Configuration Reference](../configuration/configuration.md) for the full `BridgeConfig` type, `bridgeBootstrap()` signature, route guard rules, the `.env` pattern, and the `readonlyConfig` store.

--- a/learning/feature-flags/feature-flags.md
+++ b/learning/feature-flags/feature-flags.md
@@ -68,6 +68,20 @@ const checkout = useFlag('new_checkout', false, () => ({
 }));
 ```
 
+### App-wide attributes (`bridge.attributes`)
+
+For attributes that every flag evaluation should see — not just one call site — publish them once on the unified bridge surface:
+
+```ts
+import { bridge } from '@nebulr-group/bridge-svelte';
+
+bridge.attributes.set('beta_cohort', true);                    // static value
+bridge.attributes.bind('cart_size', () => cart.items.length); // re-read on every eval
+bridge.attributes.bindMany(() => ({ theme, locale }));         // bulk getter
+```
+
+Precedence on key collision: per-call context > `bridge.attributes` > Bridge-managed providers. The `bridge:` namespace is reserved — writes to it are rejected with a console warning. See the Live Updates guide for the full `bridge.attributes` API.
+
 ### FeatureFlag component
 
 Declarative gating with optional fallback content. The snippets receive the evaluated value:
@@ -147,6 +161,8 @@ When the live channel drops, flags freeze on last-known values and refetch on re
 ### Bridge-managed attributes
 
 With Bridge auth and/or billing enabled, attributes like `bridge:user.role`, `bridge:tenant.plan`, and `bridge:billing.plan` merge into every evaluation automatically — no app code. Your own (dev-supplied) attributes always win on key collision, and the admin UI surfaces collisions on the flag detail page.
+
+With billing enabled this includes quota and entitlement attributes (`bridge:billing.quota.<metric>.*`, `bridge:billing.entitlement.<name>`) — the recommended way to gate plan-granted features is a flag whose rule targets an entitlement attribute. See the Payments guide's Entitlements section for the pattern.
 
 ### Propagating context to your backend
 

--- a/learning/live-updates/live-updates.md
+++ b/learning/live-updates/live-updates.md
@@ -1,0 +1,115 @@
+# Live Updates & the Bridge Surface
+
+Every Bridge app holds one live channel to the platform. On connect (and on every reconnect) the server pushes a `session.snapshot` with everything your UI needs — branding, workspace, subscription, entitlements, user — and after that, targeted pushes keep it current: flag changes, plan changes, payment events, quota updates. No polling, no refresh.
+
+The **`bridge` surface** is the single object that exposes all of it, grouped by scope:
+
+```svelte
+<script lang="ts">
+  import { bridge } from '@nebulr-group/bridge-svelte';
+
+  const branding = bridge.app.branding;
+  const workspace = bridge.tenant.name;
+  const subscription = bridge.tenant.subscription;
+  const user = bridge.user;
+</script>
+
+{#if $branding}<img src={$branding.logo} alt={$branding.name} />{/if}
+<p>Workspace: {$workspace}</p>
+<p>Plan: {$subscription?.plan.name}</p>
+<p>Signed in as {$user?.email}</p>
+```
+
+Every slice is a Svelte readable store. They are `null` until the channel delivers the first snapshot — gate on null for skeletons, or fall back to defaults. The `bridge` object's identity is stable; destructure and pass sub-references freely.
+
+### The scopes
+
+| Path | Type | What it holds |
+|------|------|---------------|
+| `bridge.app.branding` | `Readable<BrandingSnapshot \| null>` | Whitelabel branding: `logo`, `name`, colors, font |
+| `bridge.app.plans` | lazy slice | Full plan catalog — `await bridge.app.plans` fetches on first access |
+| `bridge.tenant.id` / `.name` | `Readable<string \| null>` | Current workspace identity |
+| `bridge.tenant.subscription` | `Readable<SubscriptionSnapshot \| null>` | Canonical plan + status + endsAt (see the Payments guide) |
+| `bridge.tenant.entitlements` | `snapshot` store + `can(key)` | Plan-granted capabilities, replaced live on change |
+| `bridge.user` | `Readable<UserSnapshot \| null>` | Authenticated user: `id`, `email`, `role`, `tenantId` |
+| `bridge.attributes` | write surface | Publish your own attributes into flag targeting (below) |
+| `bridge.events` | dispatcher | Subscribe to every live channel event (below) |
+
+### Handling live events
+
+`bridge.events.handle({...})` is the one API for reacting to channel events — use it for side effects like analytics, audit logging, or alerting (UI state updates automatically through the stores above and the drop-in components):
+
+```ts
+import { bridge } from '@nebulr-group/bridge-svelte';
+
+const unsubscribe = bridge.events.handle({
+  'flag.updated':              (m) => console.log('flag changed:', m.flag.key),
+  'subscription.plan_changed': (m) => analytics.track('plan_changed', m),
+  'quota.updated':             (m) => updateMeter(m.metric, m.remaining),
+  'session.snapshot':          (m) => analytics.track('hydrated'),
+  '*':                         (m) => debugLog(m.kind, m),
+});
+
+// later — one call removes every handler registered above
+unsubscribe();
+```
+
+Event kinds:
+
+- **Flags:** `flag.updated`, `flag.removed`
+- **Session:** `session.snapshot`, `user.state_changed`
+- **Subscription:** `subscription.plan_changed`, `subscription.created` / `updated` / `canceled` / `reactivated`, `subscription.trial_started` / `trial_ending_soon` / `trial_converted` / `trial_expired`
+- **Payments:** `payment.succeeded`, `payment.failed`, `dunning.entered` / `retry_scheduled` / `recovered` / `exhausted`
+- **Quotas & entitlements:** `quota.updated`, `entitlements.changed`
+
+Semantics worth knowing:
+
+- **Multiple handlers per kind** — every registered handler fires; registering is additive across your app.
+- **`'*'` is a fallback**, not a firehose: it fires only for kinds that have no specific handler registered (so you never double-handle).
+- **Errors are isolated** — one throwing handler doesn't block the others or break the dispatch loop.
+
+### Publishing your own attributes
+
+`bridge.attributes` is the write surface for feeding your own data into feature-flag targeting. Keys you publish here are usable in flag rules immediately and win over Bridge-managed attributes on collision:
+
+```ts
+import { bridge } from '@nebulr-group/bridge-svelte';
+
+// Static value
+bridge.attributes.set('beta_cohort', true);
+
+// Live-bound — the getter re-runs on every flag evaluation
+bridge.attributes.bind('cart_size', () => cart.items.length);
+
+// Bulk — one getter returning a whole map
+bridge.attributes.bindMany(() => ({
+  theme: currentTheme,
+  locale: navigator.language,
+}));
+
+// Read the merged map / remove keys
+bridge.attributes.get();
+bridge.attributes.unset('beta_cohort');
+```
+
+The `bridge:` namespace is reserved for Bridge-managed attributes — writes to it are rejected with a console warning. Pass `{ observed: false }` to `set`/`bind`/`bindMany` to keep a key out of attribute-discovery telemetry.
+
+### Connection status
+
+The channel's connection state is exposed as a store from the flags entry point:
+
+```svelte
+<script lang="ts">
+  import { realtimeStatus } from '@nebulr-group/bridge-svelte/flags';
+</script>
+
+{#if $realtimeStatus !== 'open'}
+  <span class="badge">reconnecting…</span>
+{/if}
+```
+
+While the channel is down, everything keeps working from the last known state — flags evaluate from cache, stores hold their last snapshot. On reconnect the server re-sends a full `session.snapshot`, so every slice updates atomically and nothing is missed.
+
+### Relationship to the module-level stores
+
+The `bridge` surface and the original module-level stores (`appConfigStore`, `subscriptionStore`, `profileStore`, `isAuthenticated`, ...) are both supported and fed by the same internal state. The `bridge` surface is the newer, scoped way to read live platform state; the module-level stores remain the API for auth state and the classic checkout flow — see the Auth and Payments guides. Use whichever fits; they don't conflict.

--- a/learning/payments/payments.md
+++ b/learning/payments/payments.md
@@ -1,36 +1,220 @@
 # Payments & Subscriptions
 
-Bridge provides a direct-API subscription system. Users pick a plan, pay via Stripe Checkout (if applicable), and return to your app. All subscription state is managed in a reactive Svelte store.
+Bridge gives every workspace one canonical subscription — a plan, a status, and an optional trial — kept live in your app over the Bridge live channel. When a payment fails, a trial nears its end, or an admin changes the plan in Stripe, your UI reflects it within seconds, without polling.
 
-### PlanSelector component
+There are two ways to consume billing state:
+
+1. **The `bridge` surface + drop-in components** (recommended) — live, reactive, zero wiring.
+2. **The classic store + service methods** — the original checkout flow. Still fully supported; see [Classic checkout & subscription store](#classic-checkout--subscription-store) below.
+
+### Live subscription state
+
+The unified `bridge` surface exposes the workspace's canonical subscription as a reactive store. It is populated by the `session.snapshot` event when the live channel connects (and on every reconnect), then updated by live pushes:
+
+```svelte
+<script lang="ts">
+  import { bridge } from '@nebulr-group/bridge-svelte';
+
+  const subscription = bridge.tenant.subscription;
+</script>
+
+{#if $subscription}
+  <p>Plan: {$subscription.plan.name} ({$subscription.status})</p>
+  {#if $subscription.endsAt}
+    <p>Renews / ends: {new Date($subscription.endsAt).toLocaleDateString()}</p>
+  {/if}
+{/if}
+```
+
+Snapshot shape:
+
+```ts
+interface SubscriptionSnapshot {
+  plan: { slug: string; name: string };
+  status: string;        // "trial" | "active" | "past_due" | "cancel_at_period_end" | "canceled"
+  endsAt?: string;       // trial end or cancellation date, when applicable
+  gateEngaged?: boolean; // true when the workspace is billing-locked
+}
+```
+
+The store is `null` until the channel delivers the first snapshot — gate on it for a skeleton state, exactly like the example above.
+
+### Drop-in components
+
+#### `<BridgeSubscriptionStatus />`
+
+Renders the current plan name + a status badge. Mounts and subscribes itself — no props required.
+
+```svelte
+<script lang="ts">
+  import { BridgeSubscriptionStatus } from '@nebulr-group/bridge-svelte';
+</script>
+
+<BridgeSubscriptionStatus />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `class` | `string` | `''` | Class applied to the root span |
+
+#### `<BridgeBillingNotice />`
+
+The unified billing banner. Renders **nothing** while the subscription is healthy, and the right notice when it needs attention — trial countdown, payment failed, dunning retries, cancellation, locked. Not dismissible; it disappears when the status flips back to healthy.
+
+```svelte
+<script lang="ts">
+  import { BridgeBillingNotice } from '@nebulr-group/bridge-svelte';
+</script>
+
+<!-- Put it once in your root layout -->
+<BridgeBillingNotice />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `chassis` | `'bar' \| 'rail' \| 'card'` | `'rail'` | Visual variant |
+| `mode` | `'soft' \| 'hard'` | `'soft'` | `soft` always renders inline; `hard` renders a full-screen lockscreen when the workspace is billing-locked |
+| `class` | `string` | `''` | Class applied to the root element |
+| `onActionClick` | `(state) => void` | — | Override the default CTA click handler |
+
+States it covers: trial active, trial ending soon, past due, cancellation scheduled, canceled, dunning retry scheduled, final retry, exhausted (locked). Each state has two role variants: workspace admins get an action CTA ("Update card", "Upgrade"); members get an informational variant pointing them to their workspace owner.
+
+#### `<BridgeQuotaBanner />`
+
+A live usage-cap banner for one metric. Renders nothing while usage is below 80% of the plan's quota (or when the plan has no quota for that metric); shows a warning at 80–94%, critical at 95%+, and over-cap copy when the limit is exceeded. Updates live on `quota.updated` pushes.
+
+```svelte
+<script lang="ts">
+  import { BridgeQuotaBanner } from '@nebulr-group/bridge-svelte';
+</script>
+
+<BridgeQuotaBanner metric="ai_completions" />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `metric` | `string` | required | Metric key to watch |
+| `label` | `string` | metric key | Humanized display label |
+| `class` | `string` | `''` | Class applied to the root element |
+| `onActionClick` | `(snap) => void` | — | Override the default Upgrade CTA handler |
+
+For a fully custom quota UI, read the underlying snapshot directly:
+
+```ts
+import { useBridge } from '@nebulr-group/bridge-auth-core';
+
+const q = useBridge().quota('ai_completions');
+// q?.used, q?.limit, q?.remaining, q?.warningLevel ('approaching' | 'critical' | null)
+```
+
+#### `<BridgePaywall />`
+
+A hard gate for workspaces that haven't picked a plan yet. While `shouldSelectPlan` is true it renders a full-screen modal with a `<PlanSelector>` inside; otherwise it renders its children.
+
+```svelte
+<script lang="ts">
+  import { BridgePaywall } from '@nebulr-group/bridge-svelte';
+</script>
+
+<BridgePaywall successRedirect="/welcome" cancelRedirect="/plans">
+  <!-- your app — only rendered once a plan is active -->
+  <slot />
+</BridgePaywall>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `successRedirect` | `string` | `'/'` | Where to send the user after a successful Stripe payment |
+| `cancelRedirect` | `string` | `'/'` | Where to send the user if they cancel checkout |
+| `onSelect` | `({ plan, price }) => void` | — | Called after free-plan selection or a direct plan change |
+| `heading` | `Snippet` | "Choose a plan" | Override the modal heading |
+
+Workspaces with `paymentsAutoRedirect: false` are exempt from the gate.
+
+### Entitlements
+
+Plans grant **entitlements** — named capabilities like `ai_completions` or `sso`. They arrive with the session snapshot and are replaced wholesale on every `entitlements.changed` push, so an upgrade unlocks features live.
+
+```svelte
+<script lang="ts">
+  import { bridge } from '@nebulr-group/bridge-svelte';
+
+  const entitlements = bridge.tenant.entitlements.snapshot;
+</script>
+
+{#if $entitlements?.ai_completions}
+  <AiPanel />
+{/if}
+```
+
+Imperative check (synchronous, fail-closed — `false` until the snapshot lands):
+
+```ts
+if (bridge.tenant.entitlements.can('ai_completions')) { /* ... */ }
+```
+
+**The recommended gating pattern is a feature flag**, not a raw conditional. Create a flag (e.g. `use_ai`) with a rule targeting `bridge:billing.entitlement.ai_completions`, then gate on the flag:
+
+```svelte
+<script lang="ts">
+  import { useFlag } from '@nebulr-group/bridge-svelte/flags';
+
+  const useAi = useFlag('use_ai', false);
+</script>
+
+{#if useAi.value}<AiPanel />{/if}
+```
+
+This gives you everything flags give you on top of the entitlement — percentage rollouts within a plan, kill switches, per-segment overrides — without code changes. The raw `entitlements.can()` conditional is the right tool when you aren't using feature flags. See the Feature Flags guide for the full list of `bridge:billing.*` targeting attributes (plan, subscription status, quotas, entitlements).
+
+> Entitlements are **billing-derived** (what the plan grants the workspace). They are not roles — use Bridge's role/privilege system for who-may-do-what inside a workspace.
+
+### Billing events
+
+For side effects — analytics, audit logs, Slack alerts — register handlers on the unified events dispatcher. This is separate from UI rendering, which the components above own:
+
+```ts
+import { bridge } from '@nebulr-group/bridge-svelte';
+
+const unsubscribe = bridge.events.handle({
+  'subscription.plan_changed': (m) => analytics.track('plan_changed', m),
+  'payment.failed':            (m) => alertOps(`Payment failed (card ••••${m.cardLast4})`),
+  'quota.updated':             (m) => updateMeter(m.metric, m.remaining),
+  'entitlements.changed':      (m) => analytics.track('entitlements', m),
+});
+```
+
+Billing event kinds: `subscription.plan_changed`, `subscription.created` / `updated` / `canceled` / `reactivated`, `subscription.trial_started` / `trial_ending_soon` / `trial_converted` / `trial_expired`, `payment.succeeded` / `payment.failed`, `dunning.entered` / `retry_scheduled` / `recovered` / `exhausted`, `quota.updated`, `entitlements.changed`.
+
+Multiple handlers can register for the same kind; one throwing handler never blocks the others.
+
+### Classic checkout & subscription store
+
+The original checkout flow — plan picker, Stripe Checkout, billing portal — remains fully supported and is what `<PlanSelector>` and `<BridgePaywall>` use under the hood.
+
+#### PlanSelector component
 
 Drop `<PlanSelector>` onto your subscription page. It loads plans and status automatically, renders plan cards, and handles free plan selection, Stripe Checkout, and plan changes.
 
 ```svelte
 <!-- src/routes/subscription/+page.svelte -->
 <script lang="ts">
-  import { PlanSelector, loadSubscription } from '@nebulr-group/bridge-svelte';
-  import { onMount } from 'svelte';
-
-  onMount(() => loadSubscription());
+  import { PlanSelector } from '@nebulr-group/bridge-svelte';
 </script>
 
-<PlanSelector
-  successUrl="https://yourapp.com/subscription/success"
-  cancelUrl="https://yourapp.com/subscription/cancel"
-/>
+<PlanSelector successRedirect="/subscription/success" cancelRedirect="/subscription/cancel" />
 ```
 
 **Props:**
 
-| Prop | Type | Required | Description |
-|------|------|----------|-------------|
-| `successUrl` | `string` | yes | Stripe redirects here after successful payment |
-| `cancelUrl` | `string` | yes | Stripe redirects here if the user cancels checkout |
-| `onSelect` | `() => void` | no | Called after a free plan is selected or a plan change completes |
-| `planCard` | `Snippet<[{ plan, prices, isCurrent, onPick }]>` | no | Override the default plan card layout |
-| `emptyState` | `Snippet` | no | Override the "no plans" message |
-| `loadingState` | `Snippet` | no | Override the loading spinner |
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `successRedirect` | `string` | `'/subscription'` | In-app route to land on after successful payment |
+| `cancelRedirect` | `string` | `'/subscription'` | In-app route to land on if the user cancels checkout |
+| `onSelect` | `({ plan, price }) => void` | — | Called after a free plan is selected or a plan change completes |
+| `planCard` | `Snippet<[{ plan, prices, isCurrent, onPick }]>` | — | Override the default plan card layout |
+| `emptyState` | `Snippet` | — | Override the "no plans" message |
+| `loadingState` | `Snippet` | — | Override the loading spinner |
 
 All standard `HTMLAttributes<HTMLDivElement>` props (`class`, `style`, `data-*`, etc.) are forwarded to the root element.
 
@@ -38,16 +222,10 @@ All standard `HTMLAttributes<HTMLDivElement>` props (`class`, `style`, `data-*`,
 
 ```svelte
 <script lang="ts">
-  import { PlanSelector, loadSubscription, type Plan, type PriceOfferSdk } from '@nebulr-group/bridge-svelte';
-  import { onMount } from 'svelte';
-
-  onMount(() => loadSubscription());
+  import { PlanSelector, type Plan, type PriceOfferSdk } from '@nebulr-group/bridge-svelte';
 </script>
 
-<PlanSelector
-  successUrl="/subscription/success"
-  cancelUrl="/subscription/cancel"
->
+<PlanSelector successRedirect="/subscription/success" cancelRedirect="/subscription/cancel">
   {#snippet planCard({ plan, prices, isCurrent, onPick })}
     <div class="plan-card" class:current={isCurrent}>
       <h2>{plan.name}</h2>
@@ -80,9 +258,9 @@ The `onPick(price)` callback handles branching internally:
 | `data-current` | `"true"` / `"false"` | Whether this card is the current plan |
 | `data-trial` | `"true"` / `"false"` | Whether this plan has a trial |
 
-### Subscription state store
+#### Subscription state store
 
-`subscriptionStore` is a readable Svelte store that holds the subscription state. Call `loadSubscription()` to populate it.
+`subscriptionStore` is a readable Svelte store that holds the checkout-flow state. Call `loadSubscription()` to populate it.
 
 ```ts
 import { subscriptionStore, loadSubscription } from '@nebulr-group/bridge-svelte';
@@ -107,32 +285,7 @@ interface SubscriptionState {
 
 `subscriptionStore` is shared across all components. Calling `loadSubscription()` once from a parent page is enough.
 
-### Stripe redirect pages
-
-Create two lightweight routes that Stripe redirects back to:
-
-```svelte
-<!-- src/routes/subscription/success/+page.svelte -->
-<script lang="ts">
-  import { loadSubscription } from '@nebulr-group/bridge-svelte';
-  import { onMount } from 'svelte';
-
-  onMount(() => loadSubscription());
-</script>
-
-<h1>Payment successful!</h1>
-<p>Your subscription is now active.</p>
-<a href="/">Back to home</a>
-```
-
-```svelte
-<!-- src/routes/subscription/cancel/+page.svelte -->
-<h1>Payment cancelled</h1>
-<p>No charges were made.</p>
-<a href="/subscription">Back to plans</a>
-```
-
-### Individual service methods
+#### Individual service methods
 
 For custom UIs that don't use `<PlanSelector>`, call the service methods directly:
 
@@ -156,6 +309,8 @@ const status = await getBridgeAuth().getSubscriptionStatus();
 const plans = await getBridgeAuth().getPlans();
 // plan.prices[n].amount === 0  → free plan (no Stripe needed)
 ```
+
+The plan catalog is also available as a lazy slice on the bridge surface: `await bridge.app.plans` (fetches on first access).
 
 **`selectFreePlan(planKey)`** — immediately activate a free plan:
 
@@ -195,7 +350,7 @@ await getBridgeAuth().changePlan('enterprise', {
 await loadSubscription();
 ```
 
-### Billing portal
+#### Billing portal
 
 Send users to the Stripe billing portal to update their payment method, view invoices, or cancel:
 
@@ -212,7 +367,7 @@ Send users to the Stripe billing portal to update their payment method, view inv
 <button onclick={openPortal}>Manage billing</button>
 ```
 
-### Subscription state reference
+#### Subscription state reference
 
 | `SubscriptionStatus` field | Type | Meaning |
 |----------------------------|------|---------|
@@ -227,7 +382,7 @@ Send users to the Stripe billing portal to update their payment method, view inv
 Decision tree:
 
 ```
-shouldSelectPlan    → show plan picker
+shouldSelectPlan    → show plan picker (or just use <BridgePaywall>)
 paymentFailed       → show error banner + "Manage billing" + plan cards (to switch)
 shouldSetupPayments → send user through startCheckout again
 trial / active      → show plan cards in "change" mode (current plan highlighted)

--- a/learning/quickstart/hosted-quickstart.md
+++ b/learning/quickstart/hosted-quickstart.md
@@ -84,22 +84,34 @@ SvelteKit requires a route file to exist so it doesn't return a 404 when Bridge 
 
 This file can be completely empty. The `BridgeBootstrap` component handles the OAuth callback token exchange automatically during bootstrap.
 
-## 6. Environment variables
+## 6. Configuration
 
-Set these in your `.env` file:
+The `config` object you pass to `bridgeBootstrap` is a `BridgeConfig`. The most common fields:
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `VITE_BRIDGE_APP_ID` | Your Bridge application ID | **(required)** |
-| `VITE_BRIDGE_API_BASE_URL` | Root URL for the Bridge API | `https://api.thebridge.dev` |
-| `VITE_BRIDGE_DEFAULT_REDIRECT_ROUTE` | Default route after login | `/` |
-| `VITE_BRIDGE_DEBUG` | Enable debug logging | `false` |
+| Field | Default | Description |
+|-------|---------|-------------|
+| `appId` | **(required)** | Your Bridge application ID |
+| `callbackUrl` | `<origin>/auth/oauth-callback` | Where the hosted login page redirects back to |
+| `defaultRedirectRoute` | `'/'` | Route to land on after login |
+| `loginRoute` | — | In-app login route — leave unset for hosted auth (that's what triggers the hosted page) |
+| `apiBaseUrl` | `https://api.thebridge.dev` | Root URL for the Bridge API (dev override) |
+| `hostedUrl` | `https://auth.thebridge.dev` | Bridge hosted UI URL (dev override) |
+| `debug` | `false` | Enable debug logging |
 
-Example `.env`:
+See the [Configuration Reference](../configuration/configuration.md) for the full list (token storage, signup route, billing routes).
+
+Rather than hardcoding environment-specific values, keep them in a `.env` file and read them with Vite's `import.meta.env` when you build the config (the `VITE_` prefix is required for values to reach the browser):
 
 ```env
 VITE_BRIDGE_APP_ID=your-app-id-here
 VITE_BRIDGE_DEFAULT_REDIRECT_ROUTE=/dashboard
+```
+
+```ts
+const config: BridgeConfig = {
+  appId: import.meta.env.VITE_BRIDGE_APP_ID,
+  defaultRedirectRoute: import.meta.env.VITE_BRIDGE_DEFAULT_REDIRECT_ROUTE ?? '/',
+};
 ```
 
 ## Next steps

--- a/learning/sdk-auth/sdk-quickstart.md
+++ b/learning/sdk-auth/sdk-quickstart.md
@@ -138,24 +138,35 @@ After a successful signup the user receives a verification email. Once verified,
 
 See [Theming & Styles](../theming/theming.md) for customization options.
 
-## 7. Environment variables
+## 7. Configuration
 
-Set these in your `.env` file:
+The `config` object you pass to `bridgeBootstrap` is a `BridgeConfig`. The most common fields:
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `VITE_BRIDGE_APP_ID` | Your Bridge application ID | **(required)** |
-| `VITE_BRIDGE_API_BASE_URL` | Root URL for the Bridge API | `https://api.thebridge.dev` |
-| `VITE_BRIDGE_DEFAULT_REDIRECT_ROUTE` | Default route after login | `/` |
-| `VITE_BRIDGE_LOGIN_ROUTE` | Route for your login page | `/login` |
-| `VITE_BRIDGE_DEBUG` | Enable debug logging | `false` |
+| Field | Default | Description |
+|-------|---------|-------------|
+| `appId` | **(required)** | Your Bridge application ID |
+| `loginRoute` | — | In-app route of your login page — unauthenticated users are redirected here |
+| `signupRoute` | — | In-app route of your signup page |
+| `defaultRedirectRoute` | `'/'` | Route to land on after login |
+| `apiBaseUrl` | `https://api.thebridge.dev` | Root URL for the Bridge API (dev override) |
+| `hostedUrl` | `https://auth.thebridge.dev` | Bridge hosted UI URL (dev override) |
+| `debug` | `false` | Enable debug logging |
 
-Example `.env`:
+See the [Configuration Reference](../configuration/configuration.md) for the full list (token storage, billing routes).
+
+Rather than hardcoding environment-specific values, keep them in a `.env` file and read them with Vite's `import.meta.env` when you build the config (the `VITE_` prefix is required for values to reach the browser):
 
 ```env
 VITE_BRIDGE_APP_ID=your-app-id-here
 VITE_BRIDGE_DEFAULT_REDIRECT_ROUTE=/dashboard
-VITE_BRIDGE_LOGIN_ROUTE=/auth/login
+```
+
+```ts
+const config: BridgeConfig = {
+  appId: import.meta.env.VITE_BRIDGE_APP_ID,
+  loginRoute: '/auth/login',
+  defaultRedirectRoute: import.meta.env.VITE_BRIDGE_DEFAULT_REDIRECT_ROUTE ?? '/',
+};
 ```
 
 ## Next steps


### PR DESCRIPTION
Svelte learning-docs update on top of v0.4.0-beta.2:

- Billing 2.0 rewrite of payments.md (bridge-surface based)
- New live-updates topic and configuration reference
- BridgeConfig sections in both quickstarts (replacing env-var sections)
- examples.md trimmed; pointers to the configuration reference

Docs-only — no version bump, no tag/publish.