### PR TITLE
TBP-403: re-export auth-core surface via bridge-svelte + 0.4.0-beta.3

### DIFF
--- a/bridge-svelte/package.json
+++ b/bridge-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebulr-group/bridge-svelte",
-  "version": "0.4.0-beta.2",
+  "version": "0.4.0-beta.3",
   "description": "Bridge Svelte library, This library helps you to add bridge authentication and feature flags, and payments to your svelte application.",
   "author": "Iman Pouya",
   "license": "MIT",

--- a/bridge-svelte/src/lib/index.ts
+++ b/bridge-svelte/src/lib/index.ts
@@ -141,6 +141,7 @@ export type {
   TenantUser,
 } from '@nebulr-group/bridge-auth-core';
 export { BridgeAuth, BridgeAuthError, HttpError, TeamService, ApiTokenService } from '@nebulr-group/bridge-auth-core';
+export type { SessionStalePayload } from '@nebulr-group/bridge-auth-core';
 export type {
   ApiToken,
   CreateApiTokenInput,


### PR DESCRIPTION
Re-exports BridgeAuth/BridgeAuthError/HttpError/TeamService/ApiTokenService + SessionStalePayload type from auth-core so consumers take auth-core only transitively via bridge-svelte (TBP-403). Bumps to 0.4.0-beta.3. auth-core 0.4.0-beta.2 already on public npm (beta). Tag v0.4.0-beta.3 after merge triggers the publish CI.