### PR TITLE
release: v0.4.0-beta.4

### DIFF
--- a/bridge-svelte/package.json
+++ b/bridge-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebulr-group/bridge-svelte",
-  "version": "0.4.0-beta.3",
+  "version": "0.4.0-beta.4",
   "description": "Bridge Svelte library, This library helps you to add bridge authentication and feature flags, and payments to your svelte application.",
   "author": "Iman Pouya",
   "license": "MIT",
@@ -67,7 +67,7 @@
     }
   },
   "dependencies": {
-    "@nebulr-group/bridge-auth-core": "0.4.0-beta.2"
+    "@nebulr-group/bridge-auth-core": "0.4.0-beta.5"
   },
   "devDependencies": {
     "@sveltejs/kit": "^2.16.0",

--- a/bridge-svelte/src/lib/core/bridge-runtime.ts
+++ b/bridge-svelte/src/lib/core/bridge-runtime.ts
@@ -130,6 +130,10 @@ export function startBridgeRuntime(options: StartBridgeRuntimeOptions = {}): voi
   });
 
   let _connectedOnce = false;
+  // Set just before we call _realtime.reauthorize() so the resulting
+  // reconnect's setOnOpen handler knows the token is already fresh and skips
+  // its proactive refresh — see the loop note in setOnOpen below.
+  let _reauthInFlight = false;
   _realtime.setOnOpen(() => {
     _setRealtimeStatus('open');
     // On reconnect (not initial connect), proactively refresh tokens.
@@ -137,7 +141,18 @@ export function startBridgeRuntime(options: StartBridgeRuntimeOptions = {}): voi
     // client missed the user.state_changed broadcast. Refreshing here
     // syncs tokens before the first post-reconnect request can fail with
     // TOKEN_VERSION_STALE.
-    if (_connectedOnce) {
+    //
+    // EXCEPT when this reconnect was caused by our OWN reauthorize() below
+    // (a token-only refresh). In that case the token is already current, so
+    // refreshing again would mint yet another JWT, which the tokenStore
+    // subscription would see as a change and reauthorize() again → reconnect
+    // → setOnOpen → refresh → … an unbounded loop that hammers /auth/token
+    // (observed ~32 cycles/sec, jamming the page's main thread and stalling
+    // every downstream wait). Only genuine, externally-triggered reconnects
+    // (network blips, server restarts) should trigger the catch-up refresh.
+    const causedByReauthorize = _reauthInFlight;
+    _reauthInFlight = false;
+    if (_connectedOnce && !causedByReauthorize) {
       getBridgeAuth().refreshTokens().catch(() => { /* best-effort; wrapFetchWithBridgeAuth is the hard fallback */ });
     }
     _connectedOnce = true;
@@ -241,6 +256,10 @@ export function startBridgeRuntime(options: StartBridgeRuntimeOptions = {}): voi
     // Centrifugo's connection-token TTL drops it. Force a reauthorize so the
     // server re-validates against the new token immediately.
     if (prevAuthToken && _currentAuthToken && prevAuthToken !== _currentAuthToken) {
+      // Flag this as a self-induced reconnect so setOnOpen does NOT fire its
+      // proactive refresh (which would mint a new token → land back here →
+      // loop forever). The token we're reauthorizing with is already current.
+      _reauthInFlight = true;
       void _realtime!.reauthorize();
     }
   });

--- a/e2e/playwright/fixtures/auth.ts
+++ b/e2e/playwright/fixtures/auth.ts
@@ -19,6 +19,37 @@ import {
 import { type PlaywrightTestAccount, TestDataClient } from '../utils/test-data-client';
 import { LONG_TIMEOUT, MED_TIMEOUT } from './timeouts';
 
+/** Shape of the token blob auth-core persists to localStorage. */
+export interface BridgeTokens {
+  accessToken?: string;
+  refreshToken?: string;
+  idToken?: string;
+}
+
+/**
+ * Read the auth-core token blob from the page's localStorage.
+ *
+ * auth-core namespaces the storage key as `bridge_tokens:<appId>` (older builds
+ * used the bare `bridge_tokens`) — match either by prefix. Returns the parsed
+ * tokens object, or `null` when absent/unparseable. Single source of truth for
+ * every token read across the e2e suite, so the key-resolution logic lives in
+ * exactly one place.
+ */
+export function readBridgeTokens(page: Page): Promise<BridgeTokens | null> {
+  return page.evaluate(() => {
+    const key = Object.keys(localStorage).find(
+      (k) => k === 'bridge_tokens' || k.startsWith('bridge_tokens:'),
+    );
+    const raw = key ? localStorage.getItem(key) : null;
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  });
+}
+
 /**
  * Extended test fixtures for authentication and test data management.
  */
@@ -188,19 +219,10 @@ export async function loginViaBridgeAuth(
   const finalUrl = page.url();
   console.log(`[login] Login complete, final URL: ${finalUrl}`);
 
-  // Verify tokens are stored in localStorage
-  const hasTokens = await page.evaluate(() => {
-    const raw = localStorage.getItem('bridge_tokens');
-    if (!raw) return false;
-    try {
-      const tokens = JSON.parse(raw);
-      return !!tokens?.accessToken;
-    } catch {
-      return false;
-    }
-  });
+  // Verify tokens are stored in localStorage.
+  const tokens = await readBridgeTokens(page);
 
-  if (!hasTokens) {
+  if (!tokens?.accessToken) {
     throw new Error(
       `Login appeared to succeed but no tokens found in localStorage. Final URL: ${finalUrl}`,
     );
@@ -239,20 +261,12 @@ export async function loginViaSdkAuth(
   const signInBtn = page.locator('button[type="submit"]:has-text("Sign in")');
   await signInBtn.click();
 
-  // Wait for tokens to appear (SDK auth stores directly)
-  await page.waitForFunction(
-    () => {
-      const raw = localStorage.getItem('bridge_tokens');
-      if (!raw) return false;
-      try {
-        const tokens = JSON.parse(raw);
-        return !!tokens?.accessToken;
-      } catch {
-        return false;
-      }
-    },
-    { timeout: LONG_TIMEOUT },
-  );
+  // Wait for tokens to appear (SDK auth stores directly).
+  await expect
+    .poll(async () => !!(await readBridgeTokens(page))?.accessToken, {
+      timeout: LONG_TIMEOUT,
+    })
+    .toBe(true);
 
   // Wait for the post-login redirect to settle
   // (handleLogin calls goto('/protected') on successful login)

--- a/e2e/playwright/tests/auth/login-logout.spec.ts
+++ b/e2e/playwright/tests/auth/login-logout.spec.ts
@@ -8,7 +8,7 @@
  * - Logout clears tokens and returns to unauthenticated state
  */
 
-import { test, expect, loginViaSdkAuth } from '../../fixtures/auth';
+import { test, expect, loginViaSdkAuth, readBridgeTokens } from '../../fixtures/auth';
 import { createCleanContext } from '../../fixtures/clean-page';
 import { LONG_TIMEOUT, MED_TIMEOUT } from '../../fixtures/timeouts';
 
@@ -40,10 +40,7 @@ test.describe('Login & Logout Flow', () => {
     try {
       await loginViaSdkAuth(page, testUser.email, testUser.password);
 
-      const tokenData = await page.evaluate(() => {
-        const raw = localStorage.getItem('bridge_tokens');
-        return raw ? JSON.parse(raw) : null;
-      });
+      const tokenData = await readBridgeTokens(page);
 
       expect(tokenData).not.toBeNull();
       expect(tokenData.accessToken).toBeTruthy();
@@ -94,15 +91,7 @@ test.describe('Login & Logout Flow', () => {
     });
 
     // Tokens should be cleared
-    const hasTokens = await page.evaluate(() => {
-      const raw = localStorage.getItem('bridge_tokens');
-      if (!raw) return false;
-      try {
-        return !!JSON.parse(raw)?.accessToken;
-      } catch {
-        return false;
-      }
-    });
+    const hasTokens = !!(await readBridgeTokens(page))?.accessToken;
 
     expect(hasTokens).toBe(false);
   });

--- a/e2e/playwright/tests/auth/token-persistence.spec.ts
+++ b/e2e/playwright/tests/auth/token-persistence.spec.ts
@@ -2,10 +2,10 @@
  * Token Persistence Tests
  *
  * Verifies that authentication tokens persist across page reloads
- * (stored in localStorage under 'bridge_tokens').
+ * (stored in localStorage under the namespaced key `bridge_tokens:<appId>`).
  */
 
-import { test, expect } from '../../fixtures/auth';
+import { test, expect, readBridgeTokens } from '../../fixtures/auth';
 import { MED_TIMEOUT } from '../../fixtures/timeouts';
 
 test.describe('Token Persistence', () => {
@@ -13,10 +13,7 @@ test.describe('Token Persistence', () => {
     const page = authenticatedPage;
 
     // Get tokens before reload
-    const tokensBefore = await page.evaluate(() => {
-      const raw = localStorage.getItem('bridge_tokens');
-      return raw ? JSON.parse(raw) : null;
-    });
+    const tokensBefore = await readBridgeTokens(page);
 
     expect(tokensBefore).not.toBeNull();
     expect(tokensBefore.accessToken).toBeTruthy();
@@ -26,10 +23,7 @@ test.describe('Token Persistence', () => {
     await page.waitForLoadState('networkidle');
 
     // Get tokens after reload
-    const tokensAfter = await page.evaluate(() => {
-      const raw = localStorage.getItem('bridge_tokens');
-      return raw ? JSON.parse(raw) : null;
-    });
+    const tokensAfter = await readBridgeTokens(page);
 
     // Tokens should still be present
     expect(tokensAfter).not.toBeNull();

--- a/e2e/playwright/tests/sdk-auth/sdk-login.spec.ts
+++ b/e2e/playwright/tests/sdk-auth/sdk-login.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, loginViaSdkAuth } from '../../fixtures/auth';
+import { test, expect, loginViaSdkAuth, readBridgeTokens } from '../../fixtures/auth';
 import { MED_TIMEOUT, LONG_TIMEOUT } from '../../fixtures/timeouts';
 
 test.describe('SDK Login', () => {
@@ -10,12 +10,8 @@ test.describe('SDK Login', () => {
     await loginViaSdkAuth(page, testUser.email, testUser.password);
 
     // Verify tokens exist
-    const hasTokens = await page.evaluate(() => {
-      const raw = localStorage.getItem('bridge_tokens');
-      if (!raw) return false;
-      const tokens = JSON.parse(raw);
-      return !!tokens?.accessToken && !!tokens?.refreshToken && !!tokens?.idToken;
-    });
+    const t = await readBridgeTokens(page);
+    const hasTokens = !!t?.accessToken && !!t?.refreshToken && !!t?.idToken;
     expect(hasTokens).toBe(true);
   });
 

--- a/e2e/playwright/tests/sdk-auth/sdk-signup-full.spec.ts
+++ b/e2e/playwright/tests/sdk-auth/sdk-signup-full.spec.ts
@@ -10,7 +10,7 @@
  * Also tests the basic signup form rendering and validation.
  */
 
-import { test, expect } from '../../fixtures/auth';
+import { test, expect, readBridgeTokens } from '../../fixtures/auth';
 import { MED_TIMEOUT, LONG_TIMEOUT } from '../../fixtures/timeouts';
 
 test.describe('SDK Signup', () => {
@@ -130,25 +130,13 @@ test.describe('SDK Signup', () => {
     await page.locator('button[type="submit"]:has-text("Sign in")').click();
 
     // Wait for tokens to appear in localStorage
-    await page.waitForFunction(
-      () => {
-        const raw = localStorage.getItem('bridge_tokens');
-        if (!raw) return false;
-        try {
-          const tokens = JSON.parse(raw);
-          return !!tokens?.accessToken;
-        } catch {
-          return false;
-        }
-      },
-      { timeout: LONG_TIMEOUT },
-    );
+    await expect
+      .poll(async () => !!(await readBridgeTokens(page))?.accessToken, {
+        timeout: LONG_TIMEOUT,
+      })
+      .toBe(true);
 
-    const hasTokens = await page.evaluate(() => {
-      const raw = localStorage.getItem('bridge_tokens');
-      const tokens = JSON.parse(raw ?? '{}');
-      return !!tokens?.accessToken;
-    });
+    const hasTokens = !!(await readBridgeTokens(page))?.accessToken;
     expect(hasTokens).toBe(true);
 
     // Cleanup

--- a/e2e/playwright/tests/subscription/welcome-paywall.spec.ts
+++ b/e2e/playwright/tests/subscription/welcome-paywall.spec.ts
@@ -16,7 +16,7 @@
  * are cleaned up in afterAll / per-test finally blocks.
  */
 
-import { test, expect, loginViaSdkAuth } from '../../fixtures/auth';
+import { test, expect, loginViaSdkAuth, readBridgeTokens } from '../../fixtures/auth';
 import { LONG_TIMEOUT, MED_TIMEOUT } from '../../fixtures/timeouts';
 
 const STRIPE_TEST_PK = process.env.STRIPE_TEST_PK || '';
@@ -36,10 +36,22 @@ test.describe('Welcome Paywall — first-time user flow', () => {
     // budget leaves no room for the rest of the flow + final assertions.
     test.setTimeout(120_000);
 
-    const planKey = `paywall-pro-${Date.now()}`;
+    // STABLE, reusable paywall plan key (NOT `paywall-pro-${Date.now()}`).
+    //
+    // Determinism rationale: the old per-run timestamped key minted a brand-new
+    // plan + Stripe price on every run, then immediately drove checkout against
+    // it — racing bridge-api's async Stripe price-sync/archive sweep
+    // (`_getActiveStripePrice` 500 "Cannot find a matching Stripe price"), and
+    // leaking a fresh Stripe price each run that piled up in the shared test
+    // account and made the sweep ever slower. With a stable key + create-if-absent
+    // (`ensurePlan`), the plan + its Stripe price are created and synced exactly
+    // ONCE; every subsequent run reuses them with NO Stripe re-sync, so by
+    // checkout time the price has been active+checkout-ready for ages. The plan is
+    // intentionally NOT deleted in teardown — it persists for reuse.
+    const planKey = 'e2e-paywall-pro';
 
     try {
-      // ---- Arrange: configure the app for Stripe + paywall, and create a paid plan
+      // ---- Arrange: configure the app for Stripe + paywall, and ensure the paid plan
       await testDataClient.configureApp({
         paymentsAutoRedirect: true,
         stripeEnabled: true,
@@ -48,10 +60,13 @@ test.describe('Welcome Paywall — first-time user flow', () => {
         currency: 'USD',
       });
 
-      await testDataClient.createPlan({
+      // Create-if-absent: on the first ever run this creates the plan and syncs
+      // its Stripe price once; on every later run it returns the existing plan
+      // WITHOUT re-triggering the Stripe archive sweep (the flake source).
+      await testDataClient.ensurePlan({
         key: planKey,
         name: 'Paywall Pro',
-        description: 'Paid plan for welcome-paywall E2E',
+        description: 'Paid plan for welcome-paywall E2E (stable, reused across runs)',
         trial: false,
         trialDays: 0,
         prices: [{ amount: 2900, currency: 'USD', recurrenceInterval: 'month' }],
@@ -73,18 +88,15 @@ test.describe('Welcome Paywall — first-time user flow', () => {
       // ---- 1. Sign in the fresh test user via SDK auth (no plan selected yet)
       await loginViaSdkAuth(page, testUser.email, testUser.password);
 
-      // Tokens should be present after SDK login
-      const tokens = await page.evaluate(() => localStorage.getItem('bridge_tokens'));
+      // Tokens should be present after SDK login.
+      const tokens = await readBridgeTokens(page);
       expect(tokens).not.toBeNull();
 
       // ---- 1b. Sanity-check that the API really considers this tenant as
       //          paywall-eligible (shouldSelectPlan=true, paymentsAutoRedirect=true).
       //          Without this assertion, a later paywall-redirect failure could
       //          be misdiagnosed as a UI bug when it is really a tenant-state bug.
-      const accessToken = await page.evaluate(() => {
-        const raw = localStorage.getItem('bridge_tokens');
-        return raw ? JSON.parse(raw).accessToken : null;
-      });
+      const accessToken = (await readBridgeTokens(page))?.accessToken ?? null;
       const probeRes = await fetch(`${envConfig.apiBaseUrl}/account/subscription/status`, {
         headers: {
           Authorization: `Bearer ${accessToken}`,
@@ -200,10 +212,13 @@ test.describe('Welcome Paywall — first-time user flow', () => {
         timeout: MED_TIMEOUT,
       });
     } finally {
-      // ---- Cleanup: delete the plan we created, restore the TEAM trial plan
-      //               that other tests rely on, and disable Stripe on the test
-      //               app. The testUser is auto-cleaned by the fixture.
-      await testDataClient.deletePlan(planKey).catch(() => {});
+      // ---- Cleanup: restore the TEAM trial plan that other tests rely on and
+      //               disable Stripe.
+      //
+      // We do NOT delete the stable `e2e-paywall-pro` plan: it is meant to persist
+      // and be reused across runs so its Stripe price stays synced+active. Deleting
+      // it would re-run the Stripe archive sweep AND force the next run to recreate
+      // (and re-race) the price — exactly the flake this change removes.
       await testDataClient
         .createPlan({
           key: 'TEAM',

--- a/e2e/playwright/utils/test-data-client.ts
+++ b/e2e/playwright/utils/test-data-client.ts
@@ -347,6 +347,42 @@ export class TestDataClient {
   }
 
   /**
+   * Idempotently ensures a plan exists (create-if-absent).
+   *
+   * When the plan already exists, bridge-api returns it WITHOUT re-running the
+   * Stripe price sync/archive sweep — so a STABLE, reusable plan's Stripe price
+   * is synced exactly once and reused on every later run. This is what makes the
+   * welcome-paywall checkout deterministic (no create-then-checkout price race).
+   */
+  async ensurePlan(planData: {
+    key: string;
+    name?: string;
+    description?: string;
+    trial?: boolean;
+    trialDays?: number;
+    prices?: Array<{ amount: number; currency: string; recurrenceInterval: string }>;
+  }): Promise<{ planId: string; key: string; name: string; created: boolean }> {
+    const response = await fetch(`${this.baseUrl}/account/test/playwright/ensure-plan`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-playwright-api-key': this.apiKey,
+      },
+      body: JSON.stringify({
+        appDomain: this.appDomain,
+        ...planData,
+      }),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`Failed to ensure plan: ${response.status} ${error}`);
+    }
+
+    return response.json();
+  }
+
+  /**
    * Deletes a plan by key for test cleanup.
    *
    * @param planKey - Plan key to delete

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "mdx-to-md": "^0.5.2"
   },
   "dependencies": {
-    "@nebulr-group/bridge-auth-core": "0.4.0-beta.2"
+    "@nebulr-group/bridge-auth-core": "0.4.0-beta.5"
   },
   "version": "0.1.0-beta.0"
 }


### PR DESCRIPTION
bridge-svelte 0.4.0-beta.4 — _reauthInFlight guard breaking the realtime/token-refresh reconnect loop + SDK-auth e2e harness repairs. Re-pins auth-core 0.4.0-beta.5.