### PR TITLE
release: v0.4.0-beta.6 — reliable paywall redirect

### DIFF
--- a/bridge-svelte/package.json
+++ b/bridge-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebulr-group/bridge-svelte",
-  "version": "0.4.0-beta.5",
+  "version": "0.4.0-beta.6",
   "description": "Bridge Svelte library, This library helps you to add bridge authentication and feature flags, and payments to your svelte application.",
   "author": "Iman Pouya",
   "license": "MIT",

--- a/bridge-svelte/src/lib/client/BridgeBootstrap.svelte
+++ b/bridge-svelte/src/lib/client/BridgeBootstrap.svelte
@@ -1,8 +1,15 @@
 <script lang="ts">
   import { beforeNavigate, goto } from '$app/navigation';
+  import { page } from '$app/stores';
   import { onMount, onDestroy } from 'svelte';
   import { createRouteGuard } from '../auth/route-guard.js';
-  import { getBridgeAuth } from '../core/bridge-instance.js';
+  import {
+    getBridgeAuth,
+    isAuthenticated,
+    subscriptionStore,
+    loadSubscription,
+    ensureAppConfig,
+  } from '../core/bridge-instance.js';
   import { bridge as bridgeSurface } from '../core/bridge.js';
   import { setBridgeContext } from '../core/use-bridge.js';
   import { getConfig } from './stores/config.store.js';
@@ -11,7 +18,6 @@
     stopBridgeRuntime,
     type StartBridgeRuntimeOptions,
   } from '../core/bridge-runtime.js';
-  import { loadSubscription, ensureAppConfig } from '../core/bridge-instance.js';
 
   // Props: optional `runtime` overrides for advanced/debug use (websocketFactory,
   // reconnect overrides, etc.); `onBootstrapComplete` callback fires after the
@@ -29,6 +35,42 @@
   setBridgeContext(bridgeSurface);
 
   const guard = createRouteGuard();
+
+  // Reactive paywall enforcement.
+  //
+  // The one-shot redirect in bridgeBootstrap() (load) only fires on the very
+  // first load — it short-circuits on every later navigation (bridgeReadyStore),
+  // so it misses the post-login case where auth + subscription state resolve a
+  // beat AFTER load() ran. This guard owns correctness: it actively loads the
+  // subscription once known-authenticated, then redirects reactively whenever
+  // `shouldSelectPlan` resolves true. Same data source as <BridgePaywall>, so the
+  // overlay and the redirect agree. The load() redirect remains a no-flash
+  // fast-path for direct loads/refreshes only.
+  $effect(() => {
+    const paywallRoute = getConfig().billing?.paywallRoute;
+    if (!paywallRoute || !$isAuthenticated) return;
+
+    const { status, loading, error } = $subscriptionStore;
+
+    // Status unknown → trigger a single load. Guarding on `!error` avoids a
+    // tight refetch loop on persistent failure (fail-pending, not fail-open);
+    // a workspace switch resets the store and re-attempts.
+    if (!status && !loading && !error) {
+      loadSubscription().catch(() => { /* surfaced via store.error */ });
+      return;
+    }
+
+    // Status known → enforce. `$page.url.pathname` makes this re-run on
+    // navigation too, so manual nav to a protected page while plan-less is
+    // also caught. Path guard prevents a redirect loop on the paywall itself.
+    if (
+      status?.shouldSelectPlan === true &&
+      status?.paymentsAutoRedirect !== false &&
+      $page.url.pathname !== paywallRoute
+    ) {
+      goto(paywallRoute);
+    }
+  });
 
   async function handleRoute(pathname: string, cancel?: () => void) {
     const decision = await guard.getNavigationDecision(pathname);


### PR DESCRIPTION
Beta for live-app testing of the paywall-redirect fix.

**Problem:** the plan-selection redirect was flaky/non-functional post-login. Root cause: the `load()` paywall check in `bridgeBootstrap()` short-circuits after the first bootstrap (`if (get(bridgeReadyStore)) return`), so it never re-runs on the SPA navigation after signup→login, and a bare reactive effect doesn't help unless something calls `loadSubscription()`.

**Fix:** a reactive paywall guard in `<BridgeBootstrap>` that actively loads the subscription once authenticated, then redirects to `billing.paywallRoute` whenever `shouldSelectPlan` resolves true — the same server-driven signals (`shouldSelectPlan` + `paymentsAutoRedirect`) the working `<BridgePaywall>` overlay uses. The `load()` redirect stays as a no-flash fast-path for direct loads.

**Opt-out preserved (no in-code toggle):** no redirect when `paywallRoute` is unset or the backend `paymentsAutoRedirect` flag is false (`bridge app update --payments-auto-redirect false`).

Isolated to `BridgeBootstrap.svelte`. auth-core untouched (stays 0.4.0-beta.7).