### PR TITLE
release: bridge-svelte 0.4.0-beta.7 (TBP-275 metered billing)

### DIFF
--- a/bridge-svelte/package.json
+++ b/bridge-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebulr-group/bridge-svelte",
-  "version": "0.4.0-beta.6",
+  "version": "0.4.0-beta.7",
   "description": "Bridge Svelte library, This library helps you to add bridge authentication and feature flags, and payments to your svelte application.",
   "author": "Iman Pouya",
   "license": "MIT",
@@ -67,7 +67,7 @@
     }
   },
   "dependencies": {
-    "@nebulr-group/bridge-auth-core": "0.4.0-beta.7"
+    "@nebulr-group/bridge-auth-core": "0.4.0-beta.8"
   },
   "devDependencies": {
     "@sveltejs/kit": "^2.16.0",

--- a/bridge-svelte/src/lib/client/components/subscription/BridgeQuotaBanner.svelte
+++ b/bridge-svelte/src/lib/client/components/subscription/BridgeQuotaBanner.svelte
@@ -96,12 +96,28 @@
   });
 
   const warningLevel = $derived(snapshot?.warningLevel ?? null);
+  // TBP-275 — `metered` quotas bill overage instead of blocking. Prefer the
+  // server-authoritative `overcap` flag (handles limit === 0 pure-per-unit)
+  // over a UI-derived `used > limit`.
+  const isMetered = $derived(snapshot?.policy === 'metered');
   const overCap = $derived(
-    snapshot ? snapshot.used > snapshot.limit : false,
+    snapshot
+      ? (snapshot.overcap ?? snapshot.used > snapshot.limit)
+      : false,
   );
-  const visible = $derived(snapshot !== undefined && warningLevel !== null);
+  // Hard caps show only at the warning thresholds. Metered quotas also show
+  // once billing has engaged (overCap), even with no warningLevel — that's the
+  // live "you're now being billed for overage" state.
+  const visible = $derived(
+    snapshot !== undefined && (warningLevel !== null || (isMetered && overCap)),
+  );
+  // Metered never blocks, so it never renders as 'critical' — it's informational.
   const severity = $derived<Severity>(
-    warningLevel === 'critical' || overCap ? 'critical' : 'warn',
+    isMetered
+      ? 'warn'
+      : warningLevel === 'critical' || overCap
+        ? 'critical'
+        : 'warn',
   );
   const displayLabel = $derived(label ?? snapshot?.label ?? metric);
   const percent = $derived(
@@ -109,13 +125,58 @@
       ? Math.min(100, Math.round((snapshot.used / snapshot.limit) * 100))
       : 0,
   );
+  // Meter bar is meaningless for pure per-unit metered (limit 0) — hide it there.
+  const showMeter = $derived(!!snapshot && snapshot.limit > 0);
+
+  /** Format an estimated cost like "$1.00" / "1.00 SEK". */
+  function formatCost(amount: number | undefined, currency: string | undefined): string {
+    if (amount === undefined) return '';
+    const cur = (currency ?? '').toUpperCase();
+    try {
+      return new Intl.NumberFormat(undefined, {
+        style: 'currency',
+        currency: cur || 'USD',
+      }).format(amount);
+    } catch {
+      // Unknown currency code → fall back to "<amount> <CUR>".
+      return `${amount.toFixed(2)}${cur ? ` ${cur}` : ''}`;
+    }
+  }
 
   function getCopy(
     snap: QuotaSnapshot | undefined,
     admin: boolean,
   ): { title: string; body: string; cta?: string } {
     if (!snap) return { title: '', body: '' };
-    const over = snap.used > snap.limit;
+
+    // TBP-275 — metered: live usage + projected cost, never a blocking message.
+    if (snap.policy === 'metered') {
+      const overUnits = snap.limit > 0 ? Math.max(0, snap.used - snap.limit) : snap.used;
+      const cost = formatCost(snap.overageEstimate, snap.currency);
+      const costSuffix = cost ? ` · ~${cost} estimated this period` : '';
+      if (snap.limit > 0) {
+        // included allotment + overage
+        if (overUnits > 0) {
+          return {
+            title: `${displayLabel} overage`,
+            body: `${overUnits.toLocaleString()} over your ${snap.limit.toLocaleString()} included${costSuffix}.`,
+          };
+        }
+        // approaching the included allotment (warningLevel drove visibility)
+        const unit = formatCost(snap.unitAmount, snap.currency);
+        return {
+          title: `${displayLabel} approaching included limit`,
+          body: `You've used ${snap.used.toLocaleString()} of ${snap.limit.toLocaleString()} included${unit ? ` — extra usage is billed at ${unit}/unit` : ''}.`,
+        };
+      }
+      // pure per-unit (limit 0) — billed from unit 1
+      return {
+        title: `${displayLabel} usage`,
+        body: `${snap.used.toLocaleString()} ${displayLabel}${costSuffix}.`,
+      };
+    }
+
+    const over = snap.overcap ?? snap.used > snap.limit;
     const remaining = Math.max(0, snap.remaining);
     if (over) {
       return admin
@@ -178,9 +239,11 @@
     <div class="bqb-content">
       <strong class="bqb-title">{copy.title}</strong>
       <span class="bqb-body">{copy.body}</span>
-      <div class="bqb-meter" aria-hidden="true">
-        <div class="bqb-meter-fill" style={`width: ${Math.min(100, percent)}%`}></div>
-      </div>
+      {#if showMeter}
+        <div class="bqb-meter" aria-hidden="true">
+          <div class="bqb-meter-fill" style={`width: ${Math.min(100, percent)}%`}></div>
+        </div>
+      {/if}
     </div>
     {#if copy.cta && isBillingAdmin}
       <button type="button" class="bqb-cta" onclick={handleAction}>{copy.cta}</button>

--- a/bridge-svelte/src/lib/client/components/subscription/PlanSelector.svelte
+++ b/bridge-svelte/src/lib/client/components/subscription/PlanSelector.svelte
@@ -121,8 +121,13 @@
     picking = true;
     pickError = null;
     try {
-      if (price.amount === 0) {
-        // Free plan — select directly
+      if (price.amount === 0 && !plan.hasCost) {
+        // Free plan — select directly. TBP-275: guard on `!plan.hasCost` so a
+        // $0-base plan that carries METERED pricing is NOT treated as free —
+        // it falls through to checkout/changePlan below, capturing a payment
+        // method so per-unit overage can be billed (US-C). Without this guard a
+        // metered $0-base plan would hit selectFreePlan, which the backend now
+        // rejects ("has a cost — use the checkout endpoint instead").
         await getBridgeAuth().selectFreePlan(plan.key);
         await loadSubscription();
         onSelect?.({ plan, price });

--- a/demo/src/lib/components/Navbar.svelte
+++ b/demo/src/lib/components/Navbar.svelte
@@ -40,6 +40,10 @@
           Subscription
         </a>
 
+        <a href="/usage-metered" class="nav-link">
+          Metered Usage
+        </a>
+
         <a href="/billing-lifecycle" class="nav-link">
           Billing Lifecycle
         </a>

--- a/demo/src/routes/usage-metered/+page.svelte
+++ b/demo/src/routes/usage-metered/+page.svelte
@@ -1,0 +1,262 @@
+<!--
+  TBP-275 — Metered / usage-based pricing demo + E2E harness.
+
+  Purpose-built, deterministic surface for the bridge-api Playwright suite
+  (e2e/playwright/tests/billing-metered/*). It exercises the full client slice:
+
+    - `getBridgeAuth().usage.report(metric, value)` → POST /usage/ingest
+    - live `quota.updated` pushes flowing into `useBridge().quota(metric)`
+    - the `<BridgeQuotaBanner>` metered branch (estimate / overcap copy)
+    - the new TBP-275 QuotaSnapshot fields: unitAmount, currency,
+      overageEstimate, overcap
+
+  Two metrics are rendered so US-A (distinct per-unit prices on one plan) and
+  US-M (pure per-unit, limit 0) can be driven from a single page. Every value
+  the tests assert on carries a stable `data-testid` so selectors never depend
+  on layout/copy.
+
+  Reporting a single event with a large `value` (one report() call) crosses a
+  cap without spraying N events — the reporter batches 10 events / 1s, so one
+  fat event flushes within ~1s and the realtime push updates the readout.
+-->
+<script lang="ts">
+  import BridgeQuotaBanner from '@bridge-svelte/lib/client/components/subscription/BridgeQuotaBanner.svelte';
+  import { getBridgeAuth } from '@bridge-svelte/lib/core/bridge-instance.js';
+  import { useBridge, type QuotaSnapshot } from '@nebulr-group/bridge-auth-core';
+  import { onMount } from 'svelte';
+
+  // Default metrics the suite drives. Both are free-form (US-O — no catalog);
+  // the plan's quota config decides whether each is metered and at what price.
+  const DEFAULT_METRICS = ['demo.metric_a', 'demo.metric_b'];
+
+  // Editable so a spec can point the harness at any metric name it provisioned.
+  let metricsCsv = $state(DEFAULT_METRICS.join(','));
+  const metrics = $derived(
+    metricsCsv
+      .split(',')
+      .map((m) => m.trim())
+      .filter(Boolean),
+  );
+
+  // Amount reported per click. A single large value crosses a cap in one event.
+  let amount = $state(1);
+
+  // Per-metric live snapshot, refreshed on every quota.updated push.
+  let snaps = $state<Record<string, QuotaSnapshot | undefined>>({});
+
+  // Queue depth (events awaiting flush) — tests poll this to know a report has
+  // been sent before asserting on the server-driven snapshot.
+  let queueDepth = $state<number | null>(null);
+
+  function refresh(): void {
+    const next: Record<string, QuotaSnapshot | undefined> = {};
+    for (const m of metrics) {
+      try {
+        next[m] = useBridge().quota(m) as QuotaSnapshot | undefined;
+      } catch {
+        // Stores not ready yet (pre-login) — leave undefined.
+      }
+    }
+    snaps = next;
+  }
+
+  async function refreshQueue(): Promise<void> {
+    try {
+      const status = await getBridgeAuth().usage.getQueueStatus();
+      queueDepth = (status as { depth?: number }).depth ?? null;
+    } catch {
+      queueDepth = null;
+    }
+  }
+
+  function report(metric: string, times = 1): void {
+    const usage = getBridgeAuth().usage;
+    for (let i = 0; i < times; i++) usage.report(metric, amount);
+    void refreshQueue();
+    // Give the 1s auto-flush + realtime round-trip time, then re-read.
+    setTimeout(() => {
+      void refreshQueue();
+      refresh();
+    }, 1400);
+  }
+
+  onMount(() => {
+    refresh();
+    void refreshQueue();
+    const unsubs: Array<() => void> = [];
+    try {
+      // Live: every quota.updated push re-renders the readout + banner.
+      unsubs.push(useBridge().quotas.subscribe(() => refresh()));
+    } catch {
+      // useBridge stores not configured yet — refresh() on mount is best-effort.
+    }
+    return () => unsubs.forEach((u) => u());
+  });
+
+  function fmt(v: unknown): string {
+    if (v === undefined || v === null) return '—';
+    return String(v);
+  }
+</script>
+
+<div class="usage-metered" data-testid="usage-metered-page">
+  <h1>Metered usage (TBP-275)</h1>
+  <p class="subtitle">
+    Reports real <code>usage.report(metric, value)</code> events and renders the
+    live <code>BridgeQuotaBanner</code> metered branch + raw
+    <code>QuotaSnapshot</code> for each metric.
+  </p>
+
+  <!-- ── Controls ─────────────────────────────────────────────────────────── -->
+  <section class="controls">
+    <label>
+      Metrics (csv)
+      <input data-testid="metrics-input" bind:value={metricsCsv} />
+    </label>
+    <label>
+      Amount / report
+      <input data-testid="amount-input" type="number" min="1" bind:value={amount} />
+    </label>
+    <span class="queue" data-testid="queue-depth">queue: {fmt(queueDepth)}</span>
+  </section>
+
+  <!-- ── Per-metric panels ────────────────────────────────────────────────── -->
+  {#each metrics as metric (metric)}
+    {@const s = snaps[metric]}
+    <section class="metric-panel" data-testid={`metric-panel-${metric}`}>
+      <header>
+        <h2 data-testid={`metric-name-${metric}`}>{metric}</h2>
+        <div class="actions">
+          <button data-testid={`report-${metric}-x1`} onclick={() => report(metric, 1)}>
+            Report ×1
+          </button>
+          <button data-testid={`report-${metric}-x10`} onclick={() => report(metric, 10)}>
+            Report ×10
+          </button>
+        </div>
+      </header>
+
+      <!-- The component under test: metered banner branch. -->
+      <BridgeQuotaBanner {metric} />
+
+      <!-- Raw snapshot readout — stable testids for deterministic assertions. -->
+      <dl class="snapshot">
+        <dt>policy</dt>
+        <dd data-testid={`snap-policy-${metric}`}>{fmt(s?.policy)}</dd>
+        <dt>used</dt>
+        <dd data-testid={`snap-used-${metric}`}>{fmt(s?.used)}</dd>
+        <dt>limit</dt>
+        <dd data-testid={`snap-limit-${metric}`}>{fmt(s?.limit)}</dd>
+        <dt>remaining</dt>
+        <dd data-testid={`snap-remaining-${metric}`}>{fmt(s?.remaining)}</dd>
+        <dt>unitAmount</dt>
+        <dd data-testid={`snap-unitAmount-${metric}`}>{fmt(s?.unitAmount)}</dd>
+        <dt>currency</dt>
+        <dd data-testid={`snap-currency-${metric}`}>{fmt(s?.currency)}</dd>
+        <dt>overageEstimate</dt>
+        <dd data-testid={`snap-overageEstimate-${metric}`}>{fmt(s?.overageEstimate)}</dd>
+        <dt>overcap</dt>
+        <dd data-testid={`snap-overcap-${metric}`}>{fmt(s?.overcap)}</dd>
+      </dl>
+    </section>
+  {/each}
+</div>
+
+<style>
+  .usage-metered {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 1.5rem;
+    font: inherit;
+  }
+
+  .subtitle {
+    color: #555;
+    font-size: 0.9rem;
+  }
+
+  .controls {
+    display: flex;
+    align-items: flex-end;
+    gap: 1rem;
+    margin: 1rem 0;
+    flex-wrap: wrap;
+  }
+
+  .controls label {
+    display: flex;
+    flex-direction: column;
+    font-size: 0.8rem;
+    gap: 0.25rem;
+  }
+
+  .controls input {
+    padding: 0.4rem 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 0.375rem;
+  }
+
+  .queue {
+    font-size: 0.8rem;
+    color: #777;
+    padding-bottom: 0.5rem;
+  }
+
+  .metric-panel {
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    padding: 1rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .metric-panel header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.75rem;
+  }
+
+  .metric-panel h2 {
+    font-size: 1rem;
+    margin: 0;
+    font-family: ui-monospace, monospace;
+  }
+
+  .actions {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .actions button {
+    padding: 0.4rem 0.75rem;
+    border: 1px solid #2563eb;
+    background: #2563eb;
+    color: white;
+    border-radius: 0.375rem;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.85rem;
+  }
+
+  .actions button:hover {
+    background: #1d4ed8;
+  }
+
+  .snapshot {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.25rem 1rem;
+    margin: 0.75rem 0 0;
+    font-size: 0.85rem;
+  }
+
+  .snapshot dt {
+    color: #6b7280;
+    font-family: ui-monospace, monospace;
+  }
+
+  .snapshot dd {
+    margin: 0;
+    font-family: ui-monospace, monospace;
+  }
+</style>

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -9,8 +9,14 @@ export default defineConfig({
 	// thrown from the plugin produces a `Redirect` instance from a different
 	// @sveltejs/kit copy, fails the demo's `instanceof Redirect` check, and
 	// surfaces as a pageerror instead of redirecting.
+	//
+	// @nebulr-group/bridge-auth-core is deduped for the same reason: the
+	// source-aliased bridge-svelte plugin and the demo's own imports must share
+	// ONE auth-core module instance, or `useBridge()` resolves to two separate
+	// quota-store singletons (the demo page reads one, the live realtime push
+	// feeds the other) — see TBP-275 usage-metered harness.
 	resolve: {
-		dedupe: ['@sveltejs/kit', 'svelte']
+		dedupe: ['@sveltejs/kit', 'svelte', '@nebulr-group/bridge-auth-core']
 	},
 
 	server: {

--- a/learning/live-updates/live-updates.md
+++ b/learning/live-updates/live-updates.md
@@ -45,6 +45,8 @@ import { bridge } from '@nebulr-group/bridge-svelte';
 const unsubscribe = bridge.events.handle({
   'flag.updated':              (m) => console.log('flag changed:', m.flag.key),
   'subscription.plan_changed': (m) => analytics.track('plan_changed', m),
+  // m.policy ('hard' | 'metered'); for metered also m.unitAmount / m.currency /
+  // m.overageEstimate / m.overcap (TBP-275) for live in-app cost display.
   'quota.updated':             (m) => updateMeter(m.metric, m.remaining),
   'session.snapshot':          (m) => analytics.track('hydrated'),
   '*':                         (m) => debugLog(m.kind, m),

--- a/learning/payments/payments.md
+++ b/learning/payments/payments.md
@@ -81,7 +81,12 @@ States it covers: trial active, trial ending soon, past due, cancellation schedu
 
 #### `<BridgeQuotaBanner />`
 
-A live usage-cap banner for one metric. Renders nothing while usage is below 80% of the plan's quota (or when the plan has no quota for that metric); shows a warning at 80–94%, critical at 95%+, and over-cap copy when the limit is exceeded. Updates live on `quota.updated` pushes.
+A live usage banner for one metric. Behaviour depends on the quota's `policy`:
+
+- **`hard`** caps — renders nothing below 80% of the limit (or when the plan has no quota for the metric); shows a warning at 80–94%, critical at 95%+, and over-cap copy when the limit is exceeded.
+- **`metered`** pricing (TBP-275) — shows live usage **and projected cost** once billing engages (usage past the included allotment, or from unit 1 when `limit = 0`). Metered banners are informational (never "critical"/blocking) and render copy like _"120 over your 1,000 included · ~$1.20 estimated this period"_ or, for pure per-unit, _"4,200 api_calls · ~$42.00 estimated this period"_.
+
+Updates live on `quota.updated` pushes.
 
 ```svelte
 <script lang="ts">
@@ -96,7 +101,7 @@ A live usage-cap banner for one metric. Renders nothing while usage is below 80%
 | `metric` | `string` | required | Metric key to watch |
 | `label` | `string` | metric key | Humanized display label |
 | `class` | `string` | `''` | Class applied to the root element |
-| `onActionClick` | `(snap) => void` | — | Override the default Upgrade CTA handler |
+| `onActionClick` | `(snap) => void` | — | Override the default Upgrade CTA handler (hard caps only) |
 
 For a fully custom quota UI, read the underlying snapshot directly:
 
@@ -105,6 +110,12 @@ import { useBridge } from '@nebulr-group/bridge-auth-core';
 
 const q = useBridge().quota('ai_completions');
 // q?.used, q?.limit, q?.remaining, q?.warningLevel ('approaching' | 'critical' | null)
+// q?.policy ('hard' | 'metered')
+// TBP-275 metered fields (present when policy === 'metered'):
+//   q?.unitAmount      per-unit price (whole currency units, e.g. 0.01)
+//   q?.currency        ISO currency of unitAmount / overageEstimate
+//   q?.overageEstimate estimated overage cost this period
+//   q?.overcap         true once billing engaged (past the allotment; limit 0 ⇒ used > 0)
 ```
 
 #### `<BridgePaywall />`

--- a/mcp/billing-prompt.md
+++ b/mcp/billing-prompt.md
@@ -141,9 +141,9 @@ Import `PlanSelector` / `BridgePaywall` from `@nebulr-group/bridge-svelte`.
 
 Skip if the plans have no per-resource limits or feature differences.
 
-> Quotas and entitlements were configured in the master prompt via `bridge plan quota set` and `bridge plan entitlement set`. This step only covers surfacing them in the UI.
+> Quotas were configured in the master prompt via `bridge plan quota set` (`--policy hard` for blocking caps, `--policy metered --price-amount <n>` for per-unit billing). Entitlements are derived from `hard` quotas automatically — there is no `plan entitlement set` command. This step only covers surfacing them in the UI.
 
-To show a live quota counter, drop in `<BridgeQuotaBanner metric="ai_completions" />` — it renders nothing if no quota is configured for the current plan.
+To show a live quota counter, drop in `<BridgeQuotaBanner metric="ai_completions" />` — it renders nothing if no quota is configured for the current plan. For **metered** quotas the banner shows live usage **and projected cost** (per-unit price × overage) and is informational (never blocking); read `useBridge().quota(metric)` for the raw `unitAmount` / `currency` / `overageEstimate` / `overcap` fields to build a custom metered cost display.
 
 To gate a feature by entitlement, use `bridge.tenant.entitlements.can('key')` from `useBridge()`. Returns `false` until hydrated (fail-closed), updates live when the plan changes or quota exhausts.
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "mdx-to-md": "^0.5.2"
   },
   "dependencies": {
-    "@nebulr-group/bridge-auth-core": "0.4.0-beta.5"
+    "@nebulr-group/bridge-auth-core": "0.4.0-beta.8"
   },
   "version": "0.1.0-beta.0"
 }


### PR DESCRIPTION
Publishes `@nebulr-group/bridge-svelte@0.4.0-beta.7` to public npm.

**Changes (TBP-275 metered billing):**
- `PlanSelector` routes $0-base **metered** plans through Stripe Checkout (via `plan.hasCost`) instead of treating amount===0 as free — fixes metered plans bypassing payment-method capture.
- `BridgeQuotaBanner` metered overage branch (live 'being billed for overage' state).
- New `usage-metered` demo route.
- Re-pins `@nebulr-group/bridge-auth-core` → **0.4.0-beta.8** (published in thebridgedev/auth-core#10).

Squashes a42bc41, 259c176. **CI here will be red until auth-core#10 merges + publishes** (it installs auth-core@0.4.0-beta.8) — expected.

https://claude.ai/code/session_01MBKFnuST7WyrzQztqT6E81