### PR TITLE
fix(ci): pin publish job's global npm to 11.x

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -152,7 +152,7 @@ jobs:
           DIST_TAG: ${{ env.DIST_TAG }}
         working-directory: ${{ inputs.working-directory }}
         run: |
-          npm install -g npm@latest
+          npm install -g npm@11
           if [ "$DIST_TAG" = "latest" ]; then
             echo "Publishing with dist-tag: latest"
             npm publish --provenance --access public


### PR DESCRIPTION
npm@latest is now 12.x, which requires Node >=22. The publish job runs on the default Node 20 runner, so `npm install -g npm@latest` fails EBADENGINE before `npm publish` ever executes. Pins to npm@11 instead — satisfies the >=11.5.1 OIDC trusted-publishing requirement while staying within npm 11's Node ^20.17 || >=22.9 engine range. Same bug/fix as thebridgedev/auth-core#12; found while releasing auth-core v0.4.0-beta.9.