### PR TITLE
release: bridge-svelte v0.4.0-beta.10

### DIFF
--- a/bridge-svelte/package.json
+++ b/bridge-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebulr-group/bridge-svelte",
-  "version": "0.4.0-beta.9",
+  "version": "0.4.0-beta.10",
   "description": "Bridge Svelte library, This library helps you to add bridge authentication and feature flags, and payments to your svelte application.",
   "author": "Iman Pouya",
   "license": "MIT",
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@simplewebauthn/browser": "^13.0.0",
-    "@nebulr-group/bridge-auth-core": "0.4.0-beta.10"
+    "@nebulr-group/bridge-auth-core": "0.4.0-beta.11"
   },
   "devDependencies": {
     "@sveltejs/kit": "^2.16.0",

--- a/bridge-svelte/src/lib/client/components/subscription/billing-manage-route.test.ts
+++ b/bridge-svelte/src/lib/client/components/subscription/billing-manage-route.test.ts
@@ -1,0 +1,351 @@
+// Billing CTA destination — config-driven manage route (TBP-451 / S1).
+//
+// Under test: the destination precedence shared by <BridgeBillingNotice> and
+// <BridgeQuotaBanner>:
+//
+//   onActionClick callback  (highest — short-circuits, no navigation at all)
+//     → `actionHref` prop
+//       → getConfig().billing?.manageRoute
+//         → '/billing'                                          (default)
+//
+// HARNESS NOTE: bridge-svelte's vitest config (vitest.config.ts) runs in a
+// `node` environment with no Svelte compiler plugin and no DOM (jsdom /
+// happy-dom / @testing-library/svelte are NOT installed anywhere in the
+// workspace), so neither component can be mounted here. Following the
+// established pattern in billing-notice-gate.test.ts and plan-selector.test.ts,
+// this file exercises an EXACT replica of the components' `handleAction()`
+// script-block logic, with the external singletons (`getConfig` from
+// config.store.js and `window.location`) injected as mocks instead of
+// module-mocking them.
+//
+// The replicas below mirror, line for line:
+//   - BridgeBillingNotice.svelte  `function handleAction()`
+//   - BridgeQuotaBanner.svelte    `function handleAction()`
+//
+// The two differ only in (a) the argument handed to `onActionClick`
+// (BillingNoticeState vs QuotaSnapshot) and (b) the quota banner's
+// `if (!snapshot) return;` guard. The destination resolution is byte-identical
+// and MUST stay that way — the "both components agree" block below is the
+// regression guard for that.
+//
+// If either component's handleAction changes, update the replica here to
+// match — a drift between the two is a test bug, not a component bug.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Injected doubles ─────────────────────────────────────────────────────────
+
+/** Shape of the slice of BridgeConfig the handler reads. */
+interface BillingConfigSlice {
+  billing?: { manageRoute?: string };
+}
+
+/**
+ * Stand-in for `getConfig()` from config.store.js. The real one THROWS when
+ * `initConfig()` has not run — the handler swallows that in a `try/catch` and
+ * falls through to the default, so the throwing variant is a first-class case.
+ */
+type GetConfig = () => BillingConfigSlice;
+
+const configWith = (manageRoute?: string): GetConfig => () =>
+  manageRoute === undefined ? {} : { billing: { manageRoute } };
+
+const uninitializedConfig: GetConfig = () => {
+  throw new Error(
+    'Config has not been initialized. Call  initConfig(...) early in app startup.',
+  );
+};
+
+/** Config initialized, but the app never declared a `billing` block. */
+const configWithoutBillingBlock: GetConfig = () => ({});
+
+// ── Replica: BridgeBillingNotice.svelte handleAction() ───────────────────────
+
+interface NoticeHarnessOptions {
+  getConfig?: GetConfig;
+  actionHref?: string;
+  onActionClick?: (state: string) => void;
+  /** Emulates SSR, where `typeof window === 'undefined'`. */
+  hasWindow?: boolean;
+}
+
+function makeNoticeHarness(opts: NoticeHarnessOptions = {}) {
+  const {
+    getConfig = uninitializedConfig,
+    actionHref,
+    onActionClick,
+    hasWindow = true,
+  } = opts;
+
+  // Records every write to `window.location.href`.
+  const navigations: string[] = [];
+  const noticeState = 'past_due';
+
+  function handleAction(): void {
+    if (onActionClick) {
+      onActionClick(noticeState);
+      return;
+    }
+    // Default: open the app's billing surface. Destination priority:
+    // `actionHref` prop → `billing.manageRoute` config → '/billing'.
+    if (hasWindow) {
+      let manageRoute: string | undefined;
+      try {
+        manageRoute = getConfig().billing?.manageRoute;
+      } catch {
+        // Config not initialized — fall through to the default.
+      }
+      navigations.push(actionHref ?? manageRoute ?? '/billing');
+    }
+  }
+
+  return { handleAction, navigations, noticeState };
+}
+
+// ── Replica: BridgeQuotaBanner.svelte handleAction() ─────────────────────────
+
+interface QuotaHarnessOptions extends NoticeHarnessOptions {
+  /**
+   * The quota banner bails out entirely when the snapshot is missing. Pass
+   * `null` to model that; omit it for the normal hydrated case. (`null` rather
+   * than `undefined` so a destructuring default can't quietly re-fill it.)
+   */
+  snapshot?: { metric: string } | null;
+}
+
+function makeQuotaHarness(opts: QuotaHarnessOptions = {}) {
+  const {
+    getConfig = uninitializedConfig,
+    actionHref,
+    onActionClick,
+    hasWindow = true,
+    snapshot = { metric: 'ai_completions' },
+  } = opts;
+
+  const navigations: string[] = [];
+
+  function handleAction(): void {
+    if (!snapshot) return;
+    if (onActionClick) {
+      onActionClick(snapshot as never);
+      return;
+    }
+    // Destination priority: `actionHref` prop → `billing.manageRoute` config
+    // → '/billing'.
+    if (hasWindow) {
+      let manageRoute: string | undefined;
+      try {
+        manageRoute = getConfig().billing?.manageRoute;
+      } catch {
+        // Config not initialized — fall through to the default.
+      }
+      navigations.push(actionHref ?? manageRoute ?? '/billing');
+    }
+  }
+
+  return { handleAction, navigations, snapshot };
+}
+
+/** The two harnesses, keyed by component, for the shared-behaviour table. */
+const HARNESSES = {
+  BridgeBillingNotice: makeNoticeHarness,
+  BridgeQuotaBanner: (opts: NoticeHarnessOptions) => makeQuotaHarness(opts),
+} satisfies Record<string, (opts: NoticeHarnessOptions) => {
+  handleAction: () => void;
+  navigations: string[];
+}>;
+
+const COMPONENTS = Object.keys(HARNESSES) as (keyof typeof HARNESSES)[];
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('Billing CTA manage-route precedence (TBP-451)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe.each(COMPONENTS)('%s', (component) => {
+    const harness = HARNESSES[component];
+
+    describe("default — '/billing'", () => {
+      it('navigates to /billing when config is uninitialized and no props are given', () => {
+        const h = harness({ getConfig: uninitializedConfig });
+        h.handleAction();
+        expect(h.navigations).toEqual(['/billing']);
+      });
+
+      it('navigates to /billing when config is loaded but has no billing block', () => {
+        const h = harness({ getConfig: configWithoutBillingBlock });
+        h.handleAction();
+        expect(h.navigations).toEqual(['/billing']);
+      });
+
+      it('navigates to /billing when billing exists but manageRoute is unset', () => {
+        const h = harness({ getConfig: () => ({ billing: {} }) });
+        h.handleAction();
+        expect(h.navigations).toEqual(['/billing']);
+      });
+    });
+
+    describe('config — billing.manageRoute', () => {
+      it('honors the configured manageRoute over the built-in default', () => {
+        const h = harness({ getConfig: configWith('/settings/billing') });
+        h.handleAction();
+        expect(h.navigations).toEqual(['/settings/billing']);
+      });
+
+      it('honors an absolute manageRoute URL verbatim', () => {
+        const h = harness({ getConfig: configWith('https://billing.example.com/portal') });
+        h.handleAction();
+        expect(h.navigations).toEqual(['https://billing.example.com/portal']);
+      });
+
+      it('reads the config on every click, so a later initConfig is picked up', () => {
+        let manageRoute: string | undefined;
+        const h = harness({ getConfig: () => ({ billing: { manageRoute } }) });
+
+        h.handleAction(); // config not yet carrying a route
+        manageRoute = '/settings/billing';
+        h.handleAction(); // same component instance, config now set
+
+        expect(h.navigations).toEqual(['/billing', '/settings/billing']);
+      });
+    });
+
+    describe('actionHref prop', () => {
+      it('overrides the configured manageRoute', () => {
+        const h = harness({
+          getConfig: configWith('/settings/billing'),
+          actionHref: '/team/upgrade',
+        });
+        h.handleAction();
+        expect(h.navigations).toEqual(['/team/upgrade']);
+      });
+
+      it('overrides the default when no config is available at all', () => {
+        const h = harness({ getConfig: uninitializedConfig, actionHref: '/team/upgrade' });
+        h.handleAction();
+        expect(h.navigations).toEqual(['/team/upgrade']);
+      });
+    });
+
+    describe('onActionClick callback (highest precedence)', () => {
+      it('wins over both actionHref and config, and performs NO navigation', () => {
+        const onActionClick = vi.fn();
+        const h = harness({
+          getConfig: configWith('/settings/billing'),
+          actionHref: '/team/upgrade',
+          onActionClick,
+        });
+        h.handleAction();
+
+        expect(onActionClick).toHaveBeenCalledOnce();
+        expect(h.navigations).toEqual([]);
+      });
+
+      it('wins even with no other destination configured', () => {
+        const onActionClick = vi.fn();
+        const h = harness({ getConfig: uninitializedConfig, onActionClick });
+        h.handleAction();
+
+        expect(onActionClick).toHaveBeenCalledOnce();
+        expect(h.navigations).toEqual([]);
+      });
+
+      it('never touches getConfig when the callback short-circuits', () => {
+        const getConfig = vi.fn(configWith('/settings/billing'));
+        const h = harness({ getConfig, onActionClick: vi.fn() });
+        h.handleAction();
+
+        expect(getConfig).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('SSR guard', () => {
+      it('does not navigate when there is no window (typeof window === undefined)', () => {
+        const h = harness({ getConfig: configWith('/settings/billing'), hasWindow: false });
+        h.handleAction();
+        expect(h.navigations).toEqual([]);
+      });
+    });
+  });
+
+  // ── Cross-component agreement ──────────────────────────────────────────────
+  //
+  // The whole point of S1 is that an app configures `billing.manageRoute` ONCE
+  // and both CTAs obey it. This block fails the moment the two handlers drift.
+
+  describe('BridgeBillingNotice and BridgeQuotaBanner resolve identically', () => {
+    const cases: { label: string; opts: NoticeHarnessOptions; expected: string[] }[] = [
+      {
+        label: 'no config, no props → /billing',
+        opts: { getConfig: uninitializedConfig },
+        expected: ['/billing'],
+      },
+      {
+        label: 'config manageRoute only',
+        opts: { getConfig: configWith('/settings/billing') },
+        expected: ['/settings/billing'],
+      },
+      {
+        label: 'actionHref beats config',
+        opts: { getConfig: configWith('/settings/billing'), actionHref: '/team/upgrade' },
+        expected: ['/team/upgrade'],
+      },
+      {
+        label: 'actionHref with no config',
+        opts: { getConfig: uninitializedConfig, actionHref: '/team/upgrade' },
+        expected: ['/team/upgrade'],
+      },
+      {
+        label: 'no window → no navigation',
+        opts: { getConfig: configWith('/settings/billing'), hasWindow: false },
+        expected: [],
+      },
+    ];
+
+    it.each(cases)('$label', ({ opts, expected }) => {
+      const notice = makeNoticeHarness(opts);
+      const quota = makeQuotaHarness(opts);
+      notice.handleAction();
+      quota.handleAction();
+
+      expect(notice.navigations).toEqual(expected);
+      expect(quota.navigations).toEqual(expected);
+      expect(quota.navigations).toEqual(notice.navigations);
+    });
+
+    it('onActionClick suppresses navigation in both components', () => {
+      const noticeCb = vi.fn();
+      const quotaCb = vi.fn();
+      const shared = { getConfig: configWith('/settings/billing'), actionHref: '/team/upgrade' };
+
+      const notice = makeNoticeHarness({ ...shared, onActionClick: noticeCb });
+      const quota = makeQuotaHarness({ ...shared, onActionClick: quotaCb });
+      notice.handleAction();
+      quota.handleAction();
+
+      expect(noticeCb).toHaveBeenCalledOnce();
+      expect(quotaCb).toHaveBeenCalledOnce();
+      expect(notice.navigations).toEqual([]);
+      expect(quota.navigations).toEqual([]);
+    });
+  });
+
+  // ── Quota-banner-only guard ────────────────────────────────────────────────
+
+  describe('BridgeQuotaBanner snapshot guard', () => {
+    it('does nothing at all — no callback, no navigation — without a snapshot', () => {
+      const onActionClick = vi.fn();
+      const h = makeQuotaHarness({
+        getConfig: configWith('/settings/billing'),
+        snapshot: null,
+        onActionClick,
+      });
+      h.handleAction();
+
+      expect(onActionClick).not.toHaveBeenCalled();
+      expect(h.navigations).toEqual([]);
+    });
+  });
+});

--- a/bridge-svelte/src/lib/styles.css
+++ b/bridge-svelte/src/lib/styles.css
@@ -936,7 +936,11 @@
 }
 
 .bridge-plan-interval-tabs {
-  display: inline-flex;
+  /* Centered above the plan cards; flex + fit-content (not inline-flex) so
+     auto margins can center it regardless of the host page's text alignment. */
+  display: flex;
+  width: fit-content;
+  margin-inline: auto;
   gap: 0.25rem;
   margin-bottom: 1.25rem;
   padding: 0.25rem;

--- a/demo/src/routes/plan-card-snippets/+page.svelte
+++ b/demo/src/routes/plan-card-snippets/+page.svelte
@@ -1,0 +1,186 @@
+<!--
+  PlanSelector customization harness (TBP-451 / S2).
+
+  <PlanSelector> exposes three snippet props for card customization:
+
+    planCard        — replaces the WHOLE card (opt out of the built-in chrome)
+    planDescription — replaces the built-in `<p class="bridge-plan-description">`
+    planFooter      — appended after the built-in price buttons
+
+  This page mounts the *partial* pair (planDescription + planFooter) so the
+  built-in card chrome — plan name, price buttons, current-plan state — must
+  keep working while the app-supplied markup renders around it. The full
+  `planCard` replacement is mounted alongside it for contrast.
+
+  Driven by bridge-api/e2e/playwright/tests/app-integration/plan-card-snippets.spec.ts.
+-->
+<script lang="ts">
+  import PlanSelector from '@bridge-svelte/lib/client/components/subscription/PlanSelector.svelte';
+  import { loadSubscription } from '@bridge-svelte/lib/core/bridge-instance.js';
+  import { onMount } from 'svelte';
+
+  onMount(() => {
+    loadSubscription();
+  });
+</script>
+
+<div class="snippets-page">
+  <h1>Plan card customization</h1>
+  <p class="subtitle">
+    <code>planDescription</code> / <code>planFooter</code> override parts of the built-in card;
+    <code>planCard</code> replaces it entirely.
+  </p>
+
+  <!-- ── Partial override: built-in card chrome + app-supplied slots ──────── -->
+  <section data-testid="partial-override">
+    <h2>Partial override <code>planDescription</code> + <code>planFooter</code></h2>
+
+    <PlanSelector>
+      {#snippet planDescription({ plan, isCurrent })}
+        <p class="custom-description" data-testid="custom-description" data-plan-key={plan.key}>
+          Custom copy for {plan.name}{isCurrent ? ' (your plan)' : ''}
+        </p>
+      {/snippet}
+
+      {#snippet planFooter({ plan, isCurrent })}
+        <div class="custom-footer" data-testid="custom-footer" data-plan-key={plan.key}>
+          <span class="footer-badge">Custom footer · {plan.key}</span>
+          {#if isCurrent}
+            <span class="footer-current" data-testid="custom-footer-current">Active subscription</span>
+          {/if}
+        </div>
+      {/snippet}
+    </PlanSelector>
+  </section>
+
+  <!-- ── Full override: the built-in card never renders ───────────────────── -->
+  <section data-testid="full-override">
+    <h2>Full override <code>planCard</code></h2>
+
+    <PlanSelector>
+      {#snippet planCard({ plan, prices, isCurrent, interval, onPick })}
+        <div class="replacement-card" data-testid="replacement-card" data-plan-key={plan.key}>
+          <h3>{plan.name}</h3>
+          <p data-testid="replacement-interval">interval: {interval}</p>
+          <p data-testid="replacement-price-count">prices: {prices.length}</p>
+          <button
+            type="button"
+            data-testid="replacement-pick"
+            disabled={isCurrent}
+            onclick={() => prices[0] && onPick(prices[0])}
+          >
+            {isCurrent ? 'Current plan' : `Pick ${plan.name}`}
+          </button>
+        </div>
+      {/snippet}
+    </PlanSelector>
+  </section>
+</div>
+
+<style>
+  .snippets-page {
+    padding: 2rem;
+    max-width: 960px;
+    margin: 0 auto;
+  }
+
+  h1 {
+    margin-bottom: 0.5rem;
+    color: #1f2937;
+  }
+
+  .subtitle {
+    margin-bottom: 1.5rem;
+    color: #6b7280;
+    font-size: 0.875rem;
+  }
+
+  h2 {
+    font-size: 1.05rem;
+    color: #1f2937;
+    margin: 0 0 0.75rem;
+  }
+
+  section {
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    padding: 1.25rem;
+    margin: 1.5rem 0;
+    background: #fff;
+  }
+
+  code {
+    background: #f3f4f6;
+    padding: 0.1rem 0.35rem;
+    border-radius: 0.25rem;
+    font-size: 0.8125rem;
+  }
+
+  .custom-description {
+    margin: 0 0 0.75rem;
+    font-size: 0.875rem;
+    color: #4c1d95;
+    font-style: italic;
+  }
+
+  .custom-footer {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px dashed #e5e7eb;
+  }
+
+  .footer-badge {
+    font-size: 0.7rem;
+    font-weight: 700;
+    padding: 0.1rem 0.4rem;
+    border-radius: 9999px;
+    background: #ede9fe;
+    color: #4c1d95;
+  }
+
+  .footer-current {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #065f46;
+  }
+
+  .replacement-card {
+    border: 2px dashed #4f46e5;
+    border-radius: 0.5rem;
+    padding: 1rem;
+  }
+
+  .replacement-card h3 {
+    margin: 0 0 0.5rem;
+    font-size: 1rem;
+    color: #1f2937;
+  }
+
+  .replacement-card p {
+    margin: 0 0 0.35rem;
+    font-size: 0.8125rem;
+    color: #6b7280;
+  }
+
+  .replacement-card button {
+    margin-top: 0.5rem;
+    padding: 0.45rem 0.9rem;
+    border: none;
+    border-radius: 0.375rem;
+    background: #4f46e5;
+    color: #fff;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .replacement-card button:disabled {
+    background: #e5e7eb;
+    color: #9ca3af;
+    cursor: not-allowed;
+  }
+</style>

--- a/learning/sdk-auth/sdk-quickstart.md
+++ b/learning/sdk-auth/sdk-quickstart.md
@@ -176,6 +176,20 @@ const config: BridgeConfig = {
 };
 ```
 
+## 8. Logging out — stay in YOUR app
+
+Always pass `redirectTo` when calling `logout()` in SDK mode:
+
+```svelte
+<button onclick={() => getBridgeAuth().logout({ redirectTo: '/auth/login' })}>
+  Log out
+</button>
+```
+
+Without `redirectTo`, `logout()` sends the user to the **hosted Bridge portal**
+(`hostedUrl`, default `auth.thebridge.dev`) instead of your in-app login page —
+which is almost never what an SDK-mode app wants.
+
 ## Next steps
 
 - **More auth UI components**: [MFA](/auth/ui/mfa/), [passkeys](/auth/ui/passkeys/), [magic link](/auth/ui/magic-link/), [SSO login button](/auth/ui/google-sso/), [switching workspaces](/auth/ui/switching-workspaces/), and [user & team management](/auth/ui/team-management/).

--- a/mcp/feature-flags-prompt.md
+++ b/mcp/feature-flags-prompt.md
@@ -90,14 +90,119 @@ Create `src/routes/flags-demo/+page.svelte` with the content below. This page us
 |------|------|----------|-------------|
 | `key` | `string` | yes | Flag key — auto-created in Bridge on first eval if it doesn't exist |
 | `defaultValue` | `T` | yes | Value returned until the cache hydrates or if the flag doesn't exist |
+| `context` | `Partial<EvalContext>` | no | Per-call eval context — see *Eval context* below |
 | `children` | `Snippet<[T]>` | no | Rendered when the flag is on (`passed: true`). Receives the typed flag value |
 | `fallback` | `Snippet<[T]>` | no | Rendered when the flag is off (`passed: false`). Receives the typed flag value |
 
 Use the same `FeatureFlag` component anywhere in the app to gate any content behind a flag.
 
+## Step 3 — Configure how the flag decides (states and rules)
+
+A flag has exactly **three states**. `off` and `on` apply to everyone; `on-with-rule` decides per visitor.
+
+| State | Meaning |
+|---|---|
+| `off` | Everyone gets the off value. A newly auto-created flag starts here |
+| `on` | Everyone gets the on value |
+| `on-with-rule` | The rule decides. Whoever matches a branch gets that branch's value; everyone else gets `otherwiseValue` |
+
+A rule is **branches + otherwiseValue + rolloutPct**, first match wins:
+
+```jsonc
+{
+  "branches": [
+    { "conditions": [ { "attribute": "tenant.plan", "operator": "in", "values": ["pro", "enterprise"] } ],
+      "returnValue": true }
+  ],
+  "otherwiseValue": false,
+  "rolloutPct": 100          // 0-100, applies to the WHOLE rule
+}
+```
+
+- Conditions inside one branch are AND-ed; add more branches for OR / different return values.
+- Operators: `eq` `neq` `contains` `not_contains` `in` `not_in` `gt` `lt` `between` `regex` `exists` `not_exists` (numeric and date operators only apply to those attribute types).
+- `attribute` is a dotted path into the eval context (next step). With Bridge Auth, `user.id` `user.role` `user.email` `tenant.id` `tenant.plan` are populated for you.
+- **`rolloutPct` below 100 requires an identity** on the eval context — bucketing is `hash(flagKey + identity) mod 100`. With no identity the SDK refuses to bucket and returns the safe value rather than randomizing per call.
+
+Configure it either in the dashboard under **Feature Control**, or from the CLI — prefer the CLI when you are an agent, since it is scriptable and verifiable:
+
+```bash
+bridge flag create --key enterprise-export --value-type boolean --state on-with-rule \
+  --rule '{"branches":[{"conditions":[{"attribute":"tenant.plan","operator":"in","values":["pro","enterprise"]}],"returnValue":true}],"otherwiseValue":false,"rolloutPct":100}'
+
+# prove the rule does what you meant, without touching the app:
+bridge flag eval enterprise-export --identity user-123 --attribute tenant.plan=pro   # → true
+bridge flag eval enterprise-export --identity user-123 --attribute tenant.plan=free  # → false
+```
+
+`bridge flag list` / `get <key>` inspect the current state. To flip a flag without touching its rule, `bridge flag update` addresses it **by id, not by key** — read the id first:
+
+```bash
+bridge flag get <key>                      # id is in the output
+bridge flag update --id <id> --state on    # or --state off | on-with-rule
+```
+
+## Step 4 — Feed the rule its inputs (eval context)
+
+Rules can only target what the app sends. Flags don't require auth — without it you supply the context yourself:
+
+```ts
+{
+  identity?: string;                    // stable per-user id — required when rolloutPct < 100
+  attributes: Record<string, unknown>;  // dotted or nested; whatever your rules target
+}
+```
+
+Per call, on the component:
+
+```svelte
+<FeatureFlag key="enterprise-export" defaultValue={false} context={{ identity: user.id, attributes: { 'tenant.plan': plan } }}>
+  {#snippet children()}<ExportButton />{/snippet}
+</FeatureFlag>
+```
+
+Or publish attributes once, app-wide, on the `bridge` singleton (package root, not `/flags`):
+
+```ts
+import { bridge } from '@nebulr-group/bridge-svelte';
+
+bridge.attributes.set('tenant.plan', plan);            // static value
+bridge.attributes.bind('seats', () => currentSeats);   // live — re-read on every eval
+bridge.attributes.bindMany(() => ({ region, betaOptIn }));
+```
+
+Per-call context wins on key collision. **With Bridge Auth**, the signed-in user's role and plan flow in automatically (`user.role`, `tenant.plan`) — no wiring needed; see `bridge guide svelte sdk-auth`.
+
+## Gating logic instead of markup
+
+`<FeatureFlag>` gates *markup*. When the flag decides **behavior or supplies a value** — which endpoint to call, a numeric limit to enforce, a `string`/`number`/JSON flag value you compute with — read it directly instead:
+
+```svelte
+<script lang="ts">
+  import { useFlag } from '@nebulr-group/bridge-svelte/flags';
+  const limit = useFlag('upload-limit', 5);   // reactive { value, passed }
+</script>
+```
+
+For anything this prompt doesn't cover — classic stores, non-runes contexts, route guards — read the docs at `learning/feature-flags/` (`using/in-logic.md`, `using/guard-routes.md`, `targeting/`) rather than guessing an API.
+
+> Flags evaluate **client-side** in SvelteKit today. There is no server-side evaluation in this SDK — don't try to read a flag in `+page.server.ts` or a `+layout.server.ts` load.
+
+## Troubleshooting
+
+Flag not appearing in the dashboard within ~30s, or a read returns the default forever:
+
+- **`<BridgeBootstrap />` is mounted and `appId` is set.** The flag layer initializes on its mount; without it every read returns the default. Confirm `VITE_BRIDGE_APP_ID` is set and `initConfig({ appId })` ran in `+layout.ts`.
+- **Something is imported from `/flags`.** That subpath import is what puts the flag runtime on the dependency graph.
+- **A flag registers only once it has been evaluated** — load a page that actually reads the key.
+- **Rule never matches?** Run `bridge flag eval <key> --identity … --attribute k=v` to see the verdict without the app in the way, then confirm the app sends those same attributes.
+- **`rolloutPct < 100` with no identity** returns the safe value by design.
+- **Realtime.** Live toggles ride the realtime channel; if a proxy blocks WebSockets the value still resolves on next load, just not instantly.
+- **First-render flicker is expected** — flags hydrate async. Set `defaultValue` to the safe-off state.
+
 ## Verify
 
 1. Navigate to `/flags-demo` in the browser. The grey striped box should appear — Bridge auto-creates `demo-flag` as off.
-2. Go to **Feature Control** in the Bridge dashboard and toggle `demo-flag` on.
+2. Go to **Feature Control** in the Bridge dashboard and toggle `demo-flag` on (or take the id from `bridge flag get demo-flag` and run `bridge flag update --id <id> --state on`).
 3. The box turns green **without a page refresh** — realtime updates are on by default.
 4. Toggle it off again to confirm it reverts.


### PR DESCRIPTION
Coordinated beta round (2026-08-11). Version bump + re-pin of `@nebulr-group/bridge-auth-core` to `0.4.0-beta.11`.

See the squashed commit for the full contents.

Refs TBP-206, TBP-451.