### PR TITLE
release: bridge-svelte v0.4.0 — graduate to stable

### DIFF
--- a/bridge-svelte/package.json
+++ b/bridge-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebulr-group/bridge-svelte",
-  "version": "0.4.0-beta.10",
+  "version": "0.4.0",
   "description": "Bridge Svelte library, This library helps you to add bridge authentication and feature flags, and payments to your svelte application.",
   "author": "Iman Pouya",
   "license": "MIT",
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@simplewebauthn/browser": "^13.0.0",
-    "@nebulr-group/bridge-auth-core": "0.4.0-beta.11"
+    "@nebulr-group/bridge-auth-core": "0.4.0"
   },
   "devDependencies": {
     "@sveltejs/kit": "^2.16.0",


### PR DESCRIPTION
Graduates the 0.4.0 line to stable (was `0.4.0-beta.10`) and re-pins `@nebulr-group/bridge-auth-core` to `0.4.0`.

Content identical to `0.4.0-beta.10`, which shipped with the 2026-08-12 production release.

**CI will be red until `bridge-auth-core@0.4.0` is published** — this branch pins a version that does not exist on npm yet. Expected; auth-core merges and publishes first, then this run is re-run before merge.