### PR TITLE
release: bridge-svelte v0.4.1 — PlanSelector free-plan dedupe + cheapest-first ordering

### DIFF
--- a/bridge-svelte/package.json
+++ b/bridge-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebulr-group/bridge-svelte",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Bridge Svelte library, This library helps you to add bridge authentication and feature flags, and payments to your svelte application.",
   "author": "Iman Pouya",
   "license": "MIT",

--- a/bridge-svelte/src/lib/client/components/subscription/PlanSelector.svelte
+++ b/bridge-svelte/src/lib/client/components/subscription/PlanSelector.svelte
@@ -91,12 +91,44 @@
       : (availableIntervals[0] ?? defaultInterval);
   });
 
-  // Prices to show for a plan under the active tab: the matching interval, plus
-  // any free (amount-0) prices which apply regardless of interval.
+  // Prices to show for a plan under the active tab — at most ONE, because each
+  // price renders its own select button.
+  //
+  // The previous filter was `p.amount === 0 || p.recurrenceInterval === selected`,
+  // where the zero-amount test short-circuited the interval test. A free plan
+  // defining both `0/month` and `0/year` therefore matched twice and rendered two
+  // identical "Select free plan" buttons — visible on The Bridge's own /plan page,
+  // whose free plan ("Startup") carries a zero price per interval.
+  //
+  // The intent behind that clause was that a free plan stays selectable under
+  // every tab, which is preserved below: prefer the active interval's price, and
+  // fall back to a free price from any interval so a free-on-yearly-only plan
+  // doesn't render as "Not available monthly".
   function pricesForInterval(plan: Plan): PriceOfferSdk[] {
-    return plan.prices.filter(
-      (p) => p.amount === 0 || p.recurrenceInterval === selectedInterval,
-    );
+    const exact = plan.prices.filter((p) => p.recurrenceInterval === selectedInterval);
+    if (exact.length > 0) return exact;
+
+    const free = plan.prices.find((p) => p.amount === 0);
+    return free ? [free] : [];
+  }
+
+  // Cheapest first. The API returns plans in catalog insertion order, which on
+  // prod is growth → starter → free — putting the free plan last, below the most
+  // expensive one.
+  //
+  // The sort key is each plan's cheapest price across ALL intervals, not the
+  // active interval's, so the order stays put when the user toggles
+  // Monthly/Yearly. A plan's tier is a property of the plan; cards reshuffling
+  // under the cursor on a tab switch is worse than the edge case it would fix
+  // (a catalog whose yearly ranking inverts its monthly one). Plans with no
+  // price sort last rather than being treated as free.
+  const sortedPlans = $derived(
+    [...(plans ?? [])].sort((a, b) => minAmount(a) - minAmount(b)),
+  );
+
+  function minAmount(plan: Plan): number {
+    const amounts = (plan.prices ?? []).map((p) => p.amount);
+    return amounts.length > 0 ? Math.min(...amounts) : Number.POSITIVE_INFINITY;
   }
 
   type UiState = 'idle' | 'payment-failed' | 'setup-payments' | 'select-plan' | 'active' | 'trial';
@@ -292,7 +324,7 @@
       {/if}
 
       <div class="bridge-plan-cards" data-bridge-plan-cards>
-        {#each plans as plan (plan.key)}
+        {#each sortedPlans as plan (plan.key)}
           {@const isCurrent = plan.key === currentPlanKey}
           {@const onPick = (price: PriceOfferSdk) => handlePick(plan, price)}
           {@const visiblePrices = pricesForInterval(plan)}

--- a/e2e/playwright/tests/subscription/plan-selector-catalog.spec.ts
+++ b/e2e/playwright/tests/subscription/plan-selector-catalog.spec.ts
@@ -1,0 +1,365 @@
+/**
+ * PlanSelector — catalog rendering (duplicate free buttons + card order).
+ *
+ * Two defects confirmed on production on 2026-08-12. Both are about how the
+ * component turns the plan catalog into cards, so both are driven from a
+ * mocked `/account/subscription/plans` payload rather than whatever the local
+ * DB happens to hold — the assertions have to be deterministic, and the prod
+ * repro (The Bridge's own `free` plan carrying `0 EUR/month` AND `0 EUR/year`)
+ * is easy to state as fixture data.
+ *
+ * BUG A — `pricesForInterval()` short-circuits on `p.amount === 0`, so *every*
+ * zero-amount price survives the interval filter. A free plan that defines a
+ * zero price for two intervals therefore renders two identical "Select free
+ * plan" buttons under every tab. The intent of the `amount === 0` branch was
+ * "a free plan stays selectable whichever interval is active" — once, not once
+ * per zero price.
+ *
+ * BUG B — nothing sorts the plans, so cards render in the API's natural order.
+ * On prod that is growth → starter → free, which buries the free plan at the
+ * bottom of the page.
+ *
+ * These tests encode the CORRECT behaviour and are expected to FAIL until
+ * PlanSelector.svelte is fixed.
+ */
+
+import type { Locator, Page } from '@playwright/test';
+import { expect, test } from '../../fixtures/auth';
+import { LONG_TIMEOUT, MED_TIMEOUT, SHORT_TIMEOUT } from '../../fixtures/timeouts';
+
+// ── Fixture catalog ────────────────────────────────────────────────────────
+
+type BillingInterval = 'day' | 'week' | 'month' | 'year';
+
+interface FixturePrice {
+  id: string;
+  amount: number;
+  currency: string;
+  recurrenceInterval: BillingInterval;
+}
+
+interface FixturePlan {
+  key: string;
+  name: string;
+  description: string;
+  trial: boolean;
+  trialDays: number;
+  hasCost: boolean;
+  prices: FixturePrice[];
+}
+
+/**
+ * The prod repro: the free plan is named "Startup" and carries a zero price
+ * for BOTH month and year. Under the current filter that is what produces the
+ * duplicate button.
+ */
+const FREE_PLAN: FixturePlan = {
+  key: 'free',
+  name: 'Startup',
+  description: 'Free forever.',
+  trial: false,
+  trialDays: 0,
+  hasCost: false,
+  prices: [
+    { id: 'price_free_month', amount: 0, currency: 'eur', recurrenceInterval: 'month' },
+    { id: 'price_free_year', amount: 0, currency: 'eur', recurrenceInterval: 'year' },
+  ],
+};
+
+const STARTER_PLAN: FixturePlan = {
+  key: 'starter',
+  name: 'Starter',
+  description: 'For small teams.',
+  trial: false,
+  trialDays: 0,
+  hasCost: true,
+  prices: [
+    { id: 'price_starter_month', amount: 10, currency: 'eur', recurrenceInterval: 'month' },
+    { id: 'price_starter_year', amount: 100, currency: 'eur', recurrenceInterval: 'year' },
+  ],
+};
+
+const GROWTH_PLAN: FixturePlan = {
+  key: 'growth',
+  name: 'Growth',
+  description: 'For scaling teams.',
+  trial: false,
+  trialDays: 0,
+  hasCost: true,
+  prices: [
+    { id: 'price_growth_month', amount: 30, currency: 'eur', recurrenceInterval: 'month' },
+    { id: 'price_growth_year', amount: 300, currency: 'eur', recurrenceInterval: 'year' },
+  ],
+};
+
+/**
+ * Deliberately served in the same "wrong" order prod's API returns:
+ * growth → starter → free. Cheapest-first would be the exact reverse here,
+ * so a component that simply preserved API order cannot pass by luck.
+ */
+const CATALOG: FixturePlan[] = [GROWTH_PLAN, STARTER_PLAN, FREE_PLAN];
+
+/**
+ * Same three plans, but the yearly prices invert the monthly ranking:
+ * monthly Starter(10) < Growth(30), yearly Growth(100) < Starter(300).
+ * Sorting on the *active* interval's price therefore produces a different
+ * card order per tab, which a sort keyed on a fixed interval cannot produce.
+ */
+const INVERTED_CATALOG: FixturePlan[] = [
+  {
+    ...GROWTH_PLAN,
+    prices: [
+      { id: 'price_growth_month', amount: 30, currency: 'eur', recurrenceInterval: 'month' },
+      { id: 'price_growth_year', amount: 100, currency: 'eur', recurrenceInterval: 'year' },
+    ],
+  },
+  {
+    ...STARTER_PLAN,
+    prices: [
+      { id: 'price_starter_month', amount: 10, currency: 'eur', recurrenceInterval: 'month' },
+      { id: 'price_starter_year', amount: 300, currency: 'eur', recurrenceInterval: 'year' },
+    ],
+  },
+  FREE_PLAN,
+];
+
+/**
+ * A workspace that has not picked a plan yet — every card stays selectable,
+ * so no button is replaced by the disabled "Current plan" label.
+ */
+const SELECT_PLAN_STATUS = {
+  paymentsEnabled: false,
+  shouldSelectPlan: true,
+  shouldSetupPayments: false,
+  paymentFailed: false,
+  trial: false,
+  trialDaysLeft: 0,
+};
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/** Same label map and display order as PlanSelector's interval tabs. */
+const INTERVAL_TAB_LABELS: Record<BillingInterval, string> = {
+  day: 'Daily',
+  week: 'Weekly',
+  month: 'Monthly',
+  year: 'Yearly',
+};
+
+/** Both fixture catalogs offer paid month and year prices, so both tabs render. */
+const TABBED_INTERVALS: BillingInterval[] = ['month', 'year'];
+
+/**
+ * Serve a fixed plan catalog to the SDK. auth-core hits
+ * `${apiBaseUrl}/account/subscription/{status,plans}`; the glob keeps this
+ * slot-agnostic (slot 0 → :3200, slot 1 → :3300, …). The explicit CORS header
+ * is needed because the demo app and bridge-api sit on different origins.
+ */
+async function mockPlanCatalog(page: Page, plans: FixturePlan[]): Promise<void> {
+  await page.route('**/account/subscription/status', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      headers: { 'access-control-allow-origin': '*' },
+      body: JSON.stringify(SELECT_PLAN_STATUS),
+    }),
+  );
+
+  await page.route('**/account/subscription/plans', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      headers: { 'access-control-allow-origin': '*' },
+      body: JSON.stringify(plans),
+    }),
+  );
+}
+
+/** Navigate to the demo's /subscription page and wait for the cards to settle. */
+async function openPlanSelector(page: Page): Promise<Locator> {
+  await page.goto('/subscription');
+  await page.waitForLoadState('networkidle');
+
+  const selector = page.locator('[data-bridge-plan-selector]');
+  await expect(selector).toBeVisible({ timeout: MED_TIMEOUT });
+  await expect(selector).toHaveAttribute('data-loading', 'false', { timeout: LONG_TIMEOUT });
+  await expect(page.locator('[data-bridge-plan-card]').first()).toBeVisible({
+    timeout: MED_TIMEOUT,
+  });
+
+  return selector;
+}
+
+/** Click an interval tab and wait for it to become the active one. */
+async function selectInterval(page: Page, interval: BillingInterval): Promise<void> {
+  const label = INTERVAL_TAB_LABELS[interval];
+  const tab = page
+    .locator('[data-bridge-plan-interval-tabs]')
+    .getByRole('button', { name: label, exact: true });
+
+  await expect(
+    tab,
+    `the fixture catalog offers paid ${label.toLowerCase()} prices, so a "${label}" interval tab must be rendered`,
+  ).toBeVisible({ timeout: SHORT_TIMEOUT });
+
+  await tab.click();
+
+  await expect(
+    tab,
+    `clicking the "${label}" tab must make it the active interval`,
+  ).toHaveAttribute('data-active', 'true', { timeout: SHORT_TIMEOUT });
+}
+
+/** The card for a plan, matched on its rendered name heading. */
+function planCard(page: Page, planName: string): Locator {
+  return page
+    .locator('[data-bridge-plan-card]')
+    .filter({ has: page.getByRole('heading', { name: planName, exact: true }) });
+}
+
+/** Rendered plan names, in DOM order. */
+async function renderedPlanOrder(page: Page): Promise<string[]> {
+  const names = await page.locator('[data-bridge-plan-cards] [data-bridge-plan-card] h3').allTextContents();
+  return names.map((name) => name.trim());
+}
+
+/** The single button label PlanSelector should show for a plan at an interval. */
+function expectedButtonLabel(plan: FixturePlan, interval: BillingInterval): string {
+  const freePrice = plan.prices.find((p) => p.amount === 0);
+  if (freePrice) return 'Select free plan';
+
+  const price = plan.prices.find((p) => p.recurrenceInterval === interval);
+  if (!price) {
+    throw new Error(
+      `Fixture error: plan "${plan.name}" has no price at interval "${interval}" — ` +
+        `this suite's fixtures are meant to price every plan at every tabbed interval.`,
+    );
+  }
+  return `${price.amount} ${price.currency.toUpperCase()} / ${price.recurrenceInterval}`;
+}
+
+/** Plan names sorted cheapest-first on the given interval; ties broken by name. */
+function cheapestFirst(plans: FixturePlan[], interval: BillingInterval): string[] {
+  const amountAt = (plan: FixturePlan): number => {
+    const free = plan.prices.find((p) => p.amount === 0);
+    if (free) return 0;
+    const price = plan.prices.find((p) => p.recurrenceInterval === interval);
+    if (!price) {
+      throw new Error(
+        `Fixture error: plan "${plan.name}" has no price at interval "${interval}".`,
+      );
+    }
+    return price.amount;
+  };
+
+  return [...plans]
+    .sort((a, b) => amountAt(a) - amountAt(b) || a.name.localeCompare(b.name))
+    .map((plan) => plan.name);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+test.describe('PlanSelector catalog rendering', () => {
+  // Regression: a free plan priced 0 for two intervals rendered a duplicate
+  // "Select free plan" button, because pricesForInterval() short-circuits the
+  // interval check on `p.amount === 0` (2026-08-12)
+  test('renders exactly one select button per plan card per interval tab', async ({
+    authenticatedPage: page,
+  }) => {
+    await mockPlanCatalog(page, CATALOG);
+    await openPlanSelector(page);
+
+    for (const interval of TABBED_INTERVALS) {
+      await selectInterval(page, interval);
+
+      for (const plan of CATALOG) {
+        const card = planCard(page, plan.name);
+        const buttons = card.getByRole('button');
+
+        await expect(
+          buttons,
+          `plan "${plan.name}" prices [${plan.prices
+            .map((p) => `${p.amount} ${p.currency}/${p.recurrenceInterval}`)
+            .join(', ')}] — under the "${INTERVAL_TAB_LABELS[interval]}" tab its card must offer ` +
+            `exactly ONE select button, not one per matching price`,
+        ).toHaveCount(1);
+
+        await expect(
+          buttons,
+          `plan "${plan.name}" under the "${INTERVAL_TAB_LABELS[interval]}" tab should offer ` +
+            `"${expectedButtonLabel(plan, interval)}"`,
+        ).toHaveText(expectedButtonLabel(plan, interval));
+
+        // The zero-price branch exists so a free plan stays pickable whichever
+        // interval is active — collapsing the duplicate must not turn the free
+        // card into "Not available monthly/yearly".
+        await expect(
+          card.locator('[data-bridge-plan-unavailable]'),
+          `plan "${plan.name}" must stay selectable under the "${INTERVAL_TAB_LABELS[interval]}" tab`,
+        ).toHaveCount(0);
+      }
+    }
+  });
+
+  // Regression: plan cards rendered in the API's natural order (growth →
+  // starter → free on prod), burying the free plan last (2026-08-12)
+  test('orders plan cards cheapest-first for the active interval', async ({
+    authenticatedPage: page,
+  }) => {
+    await mockPlanCatalog(page, CATALOG);
+    await openPlanSelector(page);
+
+    for (const interval of TABBED_INTERVALS) {
+      await selectInterval(page, interval);
+
+      const expectedOrder = cheapestFirst(CATALOG, interval);
+      expect(
+        await renderedPlanOrder(page),
+        `under the "${INTERVAL_TAB_LABELS[interval]}" tab, plan cards must render cheapest-first ` +
+          `(${expectedOrder.join(' → ')}). The API deliberately returns them as ` +
+          `[${CATALOG.map((p) => p.name).join(', ')}], so unsorted output keeps the free plan last.`,
+      ).toEqual(expectedOrder);
+    }
+  });
+
+  // The sort key is deliberately each plan's cheapest price across ALL intervals,
+  // NOT the active interval's — so switching tabs never reshuffles the cards.
+  //
+  // This catalog is the case that distinguishes the two readings: Starter is
+  // cheaper monthly (10 vs 30 EUR) but dearer yearly (300 vs 100 EUR). Sorting on
+  // the active interval would reorder the cards under the cursor on a tab switch;
+  // a plan's tier is a property of the plan, not of the billing period, so the
+  // order holds and only the prices change. An earlier revision of this spec
+  // asserted the opposite; it was inverted once the sort key was decided.
+  test('keeps plan card order stable when the active interval changes the ranking', async ({
+    authenticatedPage: page,
+  }) => {
+    await mockPlanCatalog(page, INVERTED_CATALOG);
+    await openPlanSelector(page);
+
+    const ordersByInterval: string[][] = [];
+    for (const interval of TABBED_INTERVALS) {
+      await selectInterval(page, interval);
+      ordersByInterval.push(await renderedPlanOrder(page));
+    }
+
+    const [first, ...rest] = ordersByInterval;
+    for (const [i, order] of rest.entries()) {
+      expect(
+        order,
+        `this catalog prices Starter cheaper monthly (10 vs 30 EUR) but dearer yearly ` +
+          `(300 vs 100 EUR). Card order must NOT depend on the active tab — the ` +
+          `"${INTERVAL_TAB_LABELS[TABBED_INTERVALS[i + 1]]}" tab rendered ` +
+          `${order.join(' → ')} but "${INTERVAL_TAB_LABELS[TABBED_INTERVALS[0]]}" rendered ` +
+          `${first.join(' → ')}.`,
+      ).toEqual(first);
+    }
+
+    // …and that stable order is still cheapest-first by the plan's floor price.
+    expect(
+      first,
+      `cards must be ordered by each plan's cheapest price across intervals ` +
+        `(Startup 0 → Starter 10 → Growth 30).`,
+    ).toEqual(['Startup', 'Starter', 'Growth']);
+  });
+});


### PR DESCRIPTION
Fixes two production bugs on `app.thebridge.dev/plan` (TBP-531):

- **duplicate "Select free plan" buttons** — `p.amount === 0 ||` short-circuited the interval filter, so a free plan with both `0/month` and `0/year` matched twice
- **free plan rendered last** — cards were unsorted, so they followed catalog insertion order

Also:
- re-pins `@nebulr-group/bridge-auth-core` `0.4.0-beta.10` → **`0.4.0`** (stable — auth-core graduated this morning)
- drops `bridge-svelte/package-lock.json`, which this branch still carried with Verdaccio-only pins (`0.4.0-wt4.3`, `:4873`). Deleted from `main` in #35; this stops the merge resurrecting it (TBP-527)

Verified 3/3 Playwright green against the slot-1 demo, having been 3/3 red before the fix.