### PR TITLE
release: v0.4.2 — re-pin auth-core fix, real WebAuthn E2E coverage (TBP-443)

### DIFF
--- a/bridge-svelte/package.json
+++ b/bridge-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebulr-group/bridge-svelte",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Bridge Svelte library, This library helps you to add bridge authentication and feature flags, and payments to your svelte application.",
   "author": "Iman Pouya",
   "license": "MIT",
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@simplewebauthn/browser": "^13.0.0",
-    "@nebulr-group/bridge-auth-core": "0.4.0"
+    "@nebulr-group/bridge-auth-core": "0.4.1"
   },
   "devDependencies": {
     "@sveltejs/kit": "^2.16.0",

--- a/e2e/playwright/tests/sdk-auth/sdk-passkey-ceremony.spec.ts
+++ b/e2e/playwright/tests/sdk-auth/sdk-passkey-ceremony.spec.ts
@@ -1,0 +1,191 @@
+/**
+ * SDK Passkey Ceremony (real WebAuthn) Tests — TBP-443
+ *
+ * Drives a REAL WebAuthn ceremony end to end against the running bridge-api,
+ * using Chrome's CDP WebAuthn domain with a resident-key-capable virtual
+ * authenticator (a real `navigator.credentials.create()`/`.get()` call,
+ * intercepted by a virtual authenticator instead of a physical device) from
+ * the demo's own origin (localhost). This proves a real browser accepts
+ * bridge-api's origin-derived RP ID and completes a full ceremony against
+ * it — the RP-ID derivation math itself is already covered by
+ * passkeys-rp-id.util.spec.ts; nothing else in the codebase exercises an
+ * actual WebAuthn ceremony.
+ *
+ * --- Known limitation: registration does not click through PasskeySetup.svelte ---
+ *
+ * PasskeySetup.svelte (and auth-core's DirectAuthService.getPasskeyRegistrationOptions)
+ * hard-code the `passkeySetupToken` query param. That token is only ever minted
+ * server-side by POST /auth/passkeys/request-setup-link and delivered by email —
+ * and bridge-api's local dev build short-circuits all outbound email
+ * (NebulrEmailService._send: `isDev && !SEND_EMAILS_IN_DEV` returns a fake id
+ * without ever rendering/logging/persisting the email body), so the token can't
+ * be intercepted either. Unlike the sibling forgot-password flow — which
+ * testDataClient.getPasswordResetLink() already exposes as a test-data endpoint
+ * for exactly this reason — no equivalent "mint a passkeySetupToken without
+ * sending email" endpoint exists yet. Adding one would mean modifying bridge-api
+ * application source (test.controller.ts / test-data.service.ts), which is out
+ * of scope for this test-only change. Flagged back in the test-writer report.
+ *
+ * Registration below instead drives the real registration-options /
+ * verify-registration endpoints directly from the page (same origin, same
+ * virtual authenticator, same real ceremony) using a `forgotPasswordToken`.
+ * PasskeysController's getRegistrationOptions/verifyRegistration both accept
+ * `forgotPasswordToken || passkeySetupToken` — this is an already-shipped,
+ * production code path (see PasskeysChallengeError / getCredentialsConfigFromForgotPasswordToken),
+ * not something invented for this test — and it runs through the exact same
+ * resolveRpContext / generateRegistrationOptionsJson / verifyRegistrationResponse
+ * code as the passkeySetupToken path would. It just doesn't click through the
+ * PasskeySetup.svelte component itself.
+ *
+ * Authentication DOES drive the real PasskeyLogin.svelte component end to end —
+ * getPasskeyAuthOptions() needs no token at all (SDK mode identifies the app via
+ * the x-app-id header only), so there's no email/token gap on that side.
+ */
+
+import { test, expect } from '../../fixtures/auth';
+import { MED_TIMEOUT, LONG_TIMEOUT } from '../../fixtures/timeouts';
+
+test.describe('SDK Passkey Ceremony (real WebAuthn)', () => {
+  test('register a passkey via a real ceremony, then sign in with it via PasskeyLogin', async ({
+    page,
+    testUser,
+    envConfig,
+    testDataClient,
+  }) => {
+    const apiBaseUrl = envConfig.apiBaseUrl;
+    if (!apiBaseUrl) {
+      throw new Error(
+        `envConfig.apiBaseUrl is not set for environment "${envConfig.name}" — this test needs a direct ` +
+          `bridge-api URL to drive the registration-options/verify-registration ceremony.`,
+      );
+    }
+
+    // 1. Attach a resident-key-capable CDP virtual authenticator BEFORE any
+    // WebAuthn call, so both the create() and get() ceremonies below are
+    // answered by it instead of prompting for a real device.
+    const cdp = await page.context().newCDPSession(page);
+    await cdp.send('WebAuthn.enable');
+    const { authenticatorId } = await cdp.send('WebAuthn.addVirtualAuthenticator', {
+      options: {
+        protocol: 'ctap2',
+        transport: 'internal',
+        hasResidentKey: true,
+        hasUserVerification: true,
+        isUserVerified: true,
+        automaticPresenceSimulation: true,
+      },
+    });
+
+    try {
+      await page.goto(envConfig.baseUrl);
+      await page.waitForLoadState('networkidle');
+
+      // 2. Mint a real, valid token for this user without going through email
+      // delivery (see file header for why this is a forgotPasswordToken, not
+      // a passkeySetupToken).
+      const { token } = await testDataClient.getPasswordResetLink(testUser.email, envConfig.baseUrl);
+
+      // 3. Real ceremony from the page: real registration-options fetch, real
+      // navigator.credentials.create() (answered by the virtual authenticator),
+      // real verify-registration fetch. All from the demo's own origin — this
+      // is the localhost RP-ID path end to end.
+      const regResult = await page.evaluate(
+        async ({ apiBaseUrl, appId, token }) => {
+          const b64urlToBuf = (b64url: string): ArrayBuffer => {
+            const b64 = b64url.replace(/-/g, '+').replace(/_/g, '/');
+            const pad = b64.length % 4 === 0 ? '' : '='.repeat(4 - (b64.length % 4));
+            const str = atob(b64 + pad);
+            const buf = new ArrayBuffer(str.length);
+            const bytes = new Uint8Array(buf);
+            for (let i = 0; i < str.length; i++) bytes[i] = str.charCodeAt(i);
+            return buf;
+          };
+          const bufToB64url = (buf: ArrayBuffer): string => {
+            const bytes = new Uint8Array(buf);
+            let str = '';
+            for (const b of bytes) str += String.fromCharCode(b);
+            return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+          };
+
+          const optsRes = await fetch(
+            `${apiBaseUrl}/auth/passkeys/registration-options?forgotPasswordToken=${encodeURIComponent(token)}`,
+            { headers: { 'x-app-id': appId } },
+          );
+          const optsBody = await optsRes.json();
+          if (!optsRes.ok) {
+            return { ok: false, step: 'registration-options', status: optsRes.status, body: optsBody };
+          }
+
+          const publicKey: any = {
+            ...optsBody,
+            challenge: b64urlToBuf(optsBody.challenge),
+            user: { ...optsBody.user, id: b64urlToBuf(optsBody.user.id) },
+            excludeCredentials: (optsBody.excludeCredentials || []).map((c: any) => ({
+              ...c,
+              id: b64urlToBuf(c.id),
+            })),
+          };
+
+          const credential = (await navigator.credentials.create({ publicKey })) as PublicKeyCredential;
+          const response = credential.response as AuthenticatorAttestationResponse;
+
+          const attestationResponse = {
+            id: credential.id,
+            rawId: bufToB64url(credential.rawId),
+            type: credential.type,
+            response: {
+              clientDataJSON: bufToB64url(response.clientDataJSON),
+              attestationObject: bufToB64url(response.attestationObject),
+              transports: response.getTransports ? response.getTransports() : [],
+            },
+            clientExtensionResults: credential.getClientExtensionResults(),
+          };
+
+          const verifyRes = await fetch(
+            `${apiBaseUrl}/auth/passkeys/verify-registration?forgotPasswordToken=${encodeURIComponent(token)}`,
+            {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({
+                ...attestationResponse,
+                appId,
+                sdkChallengeToken: optsBody.sdkChallengeToken,
+              }),
+            },
+          );
+          const verifyBody = await verifyRes.json().catch(() => ({}));
+          return { ok: verifyRes.ok, step: 'verify-registration', status: verifyRes.status, body: verifyBody };
+        },
+        { apiBaseUrl, appId: envConfig.appId, token },
+      );
+
+      expect(
+        regResult.ok,
+        `Real passkey registration ceremony failed at ${regResult.step} (status ${regResult.status}): ${JSON.stringify(regResult.body)}`,
+      ).toBe(true);
+      expect(regResult.body.verified).toBe(true);
+
+      // 4. Real UI ceremony: drive PasskeyLogin.svelte's actual "Sign in with
+      // Passkeys" button. It calls the real getPasskeyAuthOptions() +
+      // navigator.credentials.get() + authenticateWithPasskey() — the virtual
+      // authenticator answers with the resident credential just registered.
+      await page.goto('/auth/login');
+      await page.waitForLoadState('networkidle');
+      await page.locator('#login-email').waitFor({ state: 'visible', timeout: MED_TIMEOUT });
+
+      const passkeyBtn = page.locator('[data-bridge-passkey-login]');
+      await expect(passkeyBtn).toBeVisible({ timeout: MED_TIMEOUT });
+      await passkeyBtn.click();
+
+      // Success = real navigation to the protected page showing this user's profile —
+      // not just a 200 from verify-authentication.
+      await page.waitForURL('**/protected', { timeout: LONG_TIMEOUT });
+      await expect(page.getByText('You are currently authenticated')).toBeVisible({ timeout: MED_TIMEOUT });
+      // Both the Email and Username fields render this same address — scope to
+      // the Email row specifically so the locator doesn't match two elements.
+      await expect(page.getByText(`Email: ${testUser.email}`)).toBeVisible({ timeout: MED_TIMEOUT });
+    } finally {
+      await cdp.send('WebAuthn.removeVirtualAuthenticator', { authenticatorId }).catch(() => {});
+    }
+  });
+});

--- a/e2e/playwright/tests/sdk-auth/sdk-passkey-origin-validation.spec.ts
+++ b/e2e/playwright/tests/sdk-auth/sdk-passkey-origin-validation.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * SDK Passkey Origin Validation (live HTTP) Tests — TBP-443
+ *
+ * Hits bridge-api's real running passkeys options endpoint directly (Playwright's
+ * `request` fixture — no browser, no mocks) to assert the origin-validation half
+ * of TBP-443's per-request RP-ID resolution:
+ *   - Origin header inside the app's allowedOrigins  -> 200, rpId derived from it
+ *   - Origin header NOT in the app's allowedOrigins   -> 403 "Origin not allowed"
+ *
+ * passkeys.controller.spec.ts already asserts this with NestJS providers (and
+ * AccountApiClientService) mocked out — this asserts it against the live HTTP
+ * server, with a real app document read from the real DB.
+ *
+ * Uses a dedicated test app seeded here with an explicit, non-wildcard
+ * allowedOrigins list rather than the shared SDK test app
+ * (BRIDGE_SVELTE_TEST_DASHBOARD), whose allowedOrigins is a blanket
+ * `http://localhost:*` (set by pre-setup.ts for SDK auth generally) and so can
+ * never produce a "not allowed" case.
+ *
+ * GET /auth/passkeys/authentication-options is used (rather than
+ * registration-options) because it needs no forgotPasswordToken/passkeySetupToken —
+ * only the x-app-id header — so origin validation is exercised in isolation from
+ * any user/token setup.
+ */
+
+import { test, expect } from '../../fixtures/auth';
+
+const ALLOWED_ORIGIN = 'http://localhost:3208';
+const DISALLOWED_ORIGIN = 'http://evil.example.com';
+const TEST_APP_DOMAIN = 'BRIDGE_SVELTE_PASSKEY_ORIGIN_TEST';
+
+test.describe('SDK Passkey Origin Validation (live HTTP)', () => {
+  let appId: string;
+  let apiBaseUrl: string;
+
+  test.beforeAll(async ({ envConfig, request }) => {
+    if (!envConfig.apiBaseUrl) {
+      throw new Error(`envConfig.apiBaseUrl is not set for environment "${envConfig.name}"`);
+    }
+    apiBaseUrl = envConfig.apiBaseUrl;
+
+    // Seed a dedicated app with an explicit, non-wildcard allowedOrigins list.
+    const setupRes = await request.post(
+      `${envConfig.testDataApiUrl}/account/test/playwright/setup-test-app`,
+      {
+        headers: { 'x-playwright-api-key': envConfig.testDataApiKey },
+        data: {
+          domain: TEST_APP_DOMAIN,
+          appName: 'Bridge Svelte Passkey Origin Test',
+          ownerEmail: 'playwright-passkey-origin-test@thebridge.io',
+          ownerPassword: 'helloworld',
+        },
+      },
+    );
+    expect(setupRes.ok(), await setupRes.text()).toBe(true);
+    ({ appId } = await setupRes.json());
+
+    const configureRes = await request.post(
+      `${envConfig.testDataApiUrl}/account/test/playwright/configure-app`,
+      {
+        headers: { 'x-playwright-api-key': envConfig.testDataApiKey },
+        data: { appDomain: TEST_APP_DOMAIN, allowedOrigins: [ALLOWED_ORIGIN] },
+      },
+    );
+    expect(configureRes.ok(), await configureRes.text()).toBe(true);
+  });
+
+  test.afterAll(async ({ envConfig, request }) => {
+    await request
+      .delete(`${envConfig.testDataApiUrl}/account/test/playwright/test-app`, {
+        headers: { 'x-playwright-api-key': envConfig.testDataApiKey },
+        data: { domain: TEST_APP_DOMAIN },
+      })
+      .catch(() => {});
+  });
+
+  test('Origin in allowedOrigins -> 200 with rpId derived from that origin', async ({ request }) => {
+    const res = await request.get(`${apiBaseUrl}/auth/passkeys/authentication-options`, {
+      headers: { 'x-app-id': appId, Origin: ALLOWED_ORIGIN },
+    });
+
+    expect(res.status(), await res.text()).toBe(200);
+    const body = await res.json();
+    // deriveRpIdFromOrigin special-cases any *.localhost / localhost hostname to 'localhost'.
+    expect(body.rpId).toBe('localhost');
+  });
+
+  test('Origin NOT in allowedOrigins -> 403 Origin not allowed', async ({ request }) => {
+    const res = await request.get(`${apiBaseUrl}/auth/passkeys/authentication-options`, {
+      headers: { 'x-app-id': appId, Origin: DISALLOWED_ORIGIN },
+    });
+
+    expect(res.status()).toBe(403);
+    const body = await res.json();
+    expect(body.message).toContain('Origin not allowed');
+  });
+});


### PR DESCRIPTION
Re-pins \`@nebulr-group/bridge-auth-core\` to \`0.4.1\` (see [thebridgedev/auth-core#16](https://github.com/thebridgedev/auth-core/pull/16)), which fixes a real SDK-mode passkey bug — the \`sdkChallengeToken\` relay was missing entirely, breaking every SDK-mode passkey registration/login. Pin here is exact (\`0.4.0\` → \`0.4.1\`, not a range), so this repin is required for consumers to actually receive the fix.

Also adds new Playwright coverage that found the bug in the first place:
- \`sdk-passkey-ceremony.spec.ts\` — real WebAuthn ceremony via Chrome CDP virtual authenticator, registers then logs in through the actual \`PasskeyLogin.svelte\` component end to end.
- \`sdk-passkey-origin-validation.spec.ts\` — live origin validation against bridge-api's passkey endpoints.

**Note:** CI on this branch will be red until auth-core 0.4.1 is actually published to npm (auth-core#16 merges first) — expected, not a real failure.

154/154 unit tests passing.

Refs: TBP-443